### PR TITLE
sfm: compact features unused by stored matches

### DIFF
--- a/docs/notes/sfm-unused-feature-compaction.md
+++ b/docs/notes/sfm-unused-feature-compaction.md
@@ -1,0 +1,51 @@
+# SfM unused-feature compaction
+
+`spirula sfm map --compact-unused-features` removes, in memory only, feature
+rows that no stored match record references. It is a representation change:
+it does not rank features, remove pairs or correspondences, build tracks, or
+change mapper, camera, bundle-adjustment, assembly, or merge options. Input
+feature and match files remain unchanged. The map-only switch defaults off.
+
+## Mapping invariants
+
+Mapping uses feature counts to size per-feature arrays and correspondence-graph
+rows. Registration, triangulation, visibility, audit, split, merge, and bundle
+adjustment consume supported features, stored correspondences, or reconstructed
+observations; they do not normalize a decision by the total number of extracted
+features. Removing a row with no stored correspondence therefore changes the
+representation, not a mapping decision.
+
+An image with no referenced feature remains in the image table and camera
+group. It has empty feature arrays, contributes no correspondence-graph edge,
+and cannot be selected for registration.
+
+## Transformation
+
+1. Read `matches.bin` and allocate one `std::vector<uint32_t>` old-to-new map
+   per image, with one entry per original feature and `UINT32_MAX` as the
+   unreferenced sentinel.
+2. Validate both image IDs and both feature indices of every stored match,
+   without filtering on pair configuration.
+3. Assign retained indices in increasing original-row order using a `uint64_t`
+   counter checked before conversion to the stored `uint32_t` endpoint type.
+4. Read each feature file without descriptors in the map CLI and compact its
+   keypoint and optional RGB rows. The reusable primitive also preserves
+   descriptors when they are present.
+5. Validate image feature counts, image names/order, camera metadata, pair
+   identity/order/configuration, and pair/correspondence counts before remapping
+   both endpoints in place.
+6. Update only the in-memory image feature counts and endpoint indices.
+7. Destroy the plan before camera setup and `Mapper` construction.
+
+## Temporary storage and lifetime
+
+The only temporary proportional to the original feature count is
+`old_to_new`: one `uint32_t` entry per extracted feature. `compact_counts` and
+the image snapshots hold one small entry per image; the pair snapshots hold two
+`uint32_t` image IDs, one `int32_t` configuration, and one `size_t` match count
+per stored pair. The compact feature sets coexist with their individual loaded
+source set only while that image is compacted. The complete plan is reset before
+camera setup and before Mapper allocates its own per-feature structures.
+
+No separate peak-memory claim is inferred from this lifetime description; the
+measured end-to-end validation results belong in the pull-request evidence.

--- a/src/app/cli/sfm_main.cpp
+++ b/src/app/cli/sfm_main.cpp
@@ -30,6 +30,7 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <thread>
@@ -37,6 +38,7 @@
 
 #include "sfm/SfmConfig.h"
 #include "sfm/core/CameraSetup.h"
+#include "sfm/core/FeatureCompaction.h"
 #include "sfm/core/Log.h"
 #include "sfm/core/Features.h"
 #include "sfm/core/Image.h"
@@ -1452,6 +1454,8 @@ static int cmdMap(int argc, char** argv) {
     const std::string& featdir = cfg.feature_dir;
 
     MatchesDatabase db = readMatches(matchesPath);
+    std::optional<FeatureCompactionPlan> compaction;
+    if (cfg.compact_unused_features) compaction.emplace(buildFeatureCompactionPlan(db));
     std::vector<FeatureSet> feats(db.images.size());
     {
         // Descriptors are skipped: matching is over, and on a 5000-image
@@ -1468,7 +1472,14 @@ static int cmdMap(int argc, char** argv) {
             pool.emplace_back([&] {
                 for (size_t i = next++; i < db.images.size(); i = next++) {
                     try {
-                        feats[i] = readFeatures(featdir + "/" + db.images[i].name + ".bin", false);
+                        FeatureSet loaded =
+                            readFeatures(featdir + "/" + db.images[i].name + ".bin", false);
+                        if (compaction)
+                            feats[i] = compactFeatureSet(std::move(loaded),
+                                                         compaction->old_to_new[i],
+                                                         compaction->compact_counts[i]);
+                        else
+                            feats[i] = std::move(loaded);
                     } catch (const std::exception& e) {
                         std::lock_guard<std::mutex> lk(err_mtx);
                         if (first_error.empty()) first_error = e.what();
@@ -1479,6 +1490,23 @@ static int cmdMap(int argc, char** argv) {
         if (!first_error.empty()) {
             L::err_raw(Tag::Map, first_error);
             return 1;
+        }
+    }
+    if (compaction) {
+        remapMatches(db, *compaction, feats);
+        const FeatureCompactionStats stats = compaction->stats;
+        // old_to_new is the only temporary proportional to the original row count.
+        compaction.reset();
+        if (opt.verbose) {
+            const double removed_pct = stats.original_features
+                                           ? 100.0 * stats.removedFeatures() /
+                                                 stats.original_features
+                                           : 0.0;
+            L::out(Tag::Map, M::map_feature_compaction,
+                   {(long long)stats.original_features, (long long)stats.compact_features,
+                    (long long)stats.removedFeatures(), L::num(removed_pct, 2),
+                    (long long)stats.images, (long long)stats.zero_feature_images,
+                    (long long)stats.pairs, (long long)stats.correspondences});
         }
     }
 

--- a/src/i18n/catalog/Sfm.h
+++ b/src/i18n/catalog/Sfm.h
@@ -879,6 +879,42 @@ SS_MSG(focal_search,
 // Mapping
 // ===========================================================================
 
+SS_MSG(map_feature_compaction,
+    EN("Unused-feature compaction: features {0} -> {1}; removed {2} ({3}%); images {4}; "
+       "zero-active images {5}; stored pairs {6}; correspondences {7}"),
+    JA("未使用特徴点の整理: 特徴点 {0} -> {1}; 削除 {2} ({3}%); 画像 {4}; "
+       "使用特徴点がない画像 {5}; 保存されたペア {6}; 対応点 {7}"),
+    ZH_HANS("整理未用特征点: 特征点 {0} -> {1}; 移除 {2} ({3}%); 图像 {4}; "
+            "使用特征点为零的图像 {5}; 已存储图像对 {6}; 对应关系 {7}"),
+    ZH_HANT("整理未用特徵點: 特徵點 {0} -> {1}; 移除 {2} ({3}%); 影像 {4}; "
+            "使用特徵點為零的影像 {5}; 已儲存影像對 {6}; 對應關係 {7}"),
+    KO("미사용 특징점 정리: 특징점 {0} -> {1}; 제거 {2} ({3}%); 이미지 {4}; "
+       "사용 특징점이 없는 이미지 {5}; 저장된 쌍 {6}; 대응점 {7}"),
+    DE("Komprimierung ungenutzter Merkmale: Merkmale {0} -> {1}; entfernt {2} ({3}%); "
+       "Bilder {4}; Bilder ohne aktive Merkmale {5}; gespeicherte Paare {6}; "
+       "Korrespondenzen {7}"),
+    FR("Compactage des points inutilisés : points {0} -> {1} ; retirés {2} ({3} %) ; "
+       "images {4} ; images sans point actif {5} ; paires stockées {6} ; "
+       "correspondances {7}"),
+    ES("Compactación de puntos no usados: puntos {0} -> {1}; eliminados {2} ({3}%); "
+       "imágenes {4}; imágenes sin puntos activos {5}; pares almacenados {6}; "
+       "correspondencias {7}"),
+    PT("Compactação de pontos não usados: pontos {0} -> {1}; removidos {2} ({3}%); "
+       "imagens {4}; imagens sem pontos ativos {5}; pares armazenados {6}; "
+       "correspondências {7}"),
+    IT("Compattazione dei punti inutilizzati: punti {0} -> {1}; rimossi {2} ({3}%); "
+       "immagini {4}; immagini senza punti attivi {5}; coppie memorizzate {6}; "
+       "corrispondenze {7}"),
+    NL("Compactie van ongebruikte kenmerken: kenmerken {0} -> {1}; verwijderd {2} ({3}%); "
+       "afbeeldingen {4}; afbeeldingen zonder actieve kenmerken {5}; opgeslagen paren {6}; "
+       "overeenkomsten {7}"),
+    RU("Сжатие неиспользуемых признаков: признаки {0} -> {1}; удалено {2} ({3}%); "
+       "изображения {4}; изображения без активных признаков {5}; сохранённые пары {6}; "
+       "соответствия {7}"),
+    TR("Kullanılmayan öznitelik sıkıştırması: öznitelikler {0} -> {1}; kaldırılan {2} "
+       "({3}%); görüntüler {4}; etkin özniteliği olmayan görüntüler {5}; saklanan çiftler "
+       "{6}; eşleşmeler {7}"));
+
 SS_MSG(map_seed_relax,
     EN("No seed pair passed the current thresholds; relaxing to inliers {0}, angle {1} degrees"),
     JA("現在のしきい値では初期ペアが見つかりません。インライア {0}、角度 {1} 度まで緩めます"),

--- a/src/i18n/catalog/SfmFields.h
+++ b/src/i18n/catalog/SfmFields.h
@@ -1024,6 +1024,32 @@ SS_MSG(prefilter_ratio_help,
 // mapper
 // ===========================================================================
 
+SS_MSG(compact_unused_features_help,
+    EN("Keep in memory only feature rows referenced by stored matches; files on "
+       "disk stay unchanged"),
+    JA("保存済みマッチが参照する特徴点行だけをメモリに保持します。ディスク上の"
+       "ファイルは変更しません"),
+    ZH_HANS("内存中只保留已存储匹配所引用的特征行；磁盘上的文件保持不变"),
+    ZH_HANT("記憶體中只保留已儲存匹配所引用的特徵列；磁碟上的檔案保持不變"),
+    KO("저장된 매치가 참조하는 특징점 행만 메모리에 유지합니다. 디스크의 파일은 "
+       "변경하지 않습니다"),
+    DE("Im Speicher nur Merkmalszeilen behalten, auf die gespeicherte Matches "
+       "verweisen; Dateien auf dem Datenträger bleiben unverändert"),
+    FR("Ne garder en mémoire que les lignes de points référencées par les "
+       "correspondances stockées ; les fichiers restent inchangés sur le disque"),
+    ES("Mantener en memoria solo las filas de puntos referenciadas por las "
+       "correspondencias almacenadas; los archivos del disco no cambian"),
+    PT("Manter na memória apenas as linhas de pontos referenciadas pelas "
+       "correspondências armazenadas; os arquivos no disco não mudam"),
+    IT("Mantenere in memoria solo le righe dei punti richiamate dalle "
+       "corrispondenze memorizzate; i file su disco restano invariati"),
+    NL("Alleen kenmerkrijen waar opgeslagen overeenkomsten naar verwijzen in het "
+       "geheugen houden; bestanden op schijf blijven ongewijzigd"),
+    RU("Оставлять в памяти только строки признаков, на которые ссылаются сохранённые "
+       "соответствия; файлы на диске не изменяются"),
+    TR("Bellekte yalnızca saklanan eşleşmelerin başvurduğu öznitelik satırlarını "
+       "tut; diskteki dosyalar değişmeden kalır"));
+
 SS_MSG(focal_trials_help,
     EN("Trial reconstructions used to pick a focal the motion cannot determine "
        "(D48), 0 to skip"),

--- a/src/sfm/README.md
+++ b/src/sfm/README.md
@@ -220,6 +220,7 @@ spirula sfm auto IMAGES/ -o ws/ --camera-model opencv-fisheye
 spirula sfm extract IMAGES/ -o feats/
 spirula sfm match   feats/ -o matches.bin
 spirula sfm map     matches.bin feats/ -o sparse/ --images IMAGES/
+spirula sfm map     matches.bin feats/ -o sparse/ --compact-unused-features
 spirula sfm merge   sparse/ -o merged/
 spirula sfm ba      problem.txt --real df       # solver benchmark on a BAL problem
 ```
@@ -244,6 +245,16 @@ Japanese still moves the bar (`app/gui/SfmRunner.cpp`).
 Environment: `SS_SFM_MAP_PROF=1` prints a mapper stage breakdown,
 `SS_SFM_DUMP_SG` / `SS_SFM_CMP_STEP` are BA solver debug hooks
 (`ba/README.md`).
+
+`map --compact-unused-features` is an opt-in in-memory representation change.
+It retains the feature rows referenced by stored match records in stable order,
+remaps every stored match endpoint, and releases the temporary index map before
+constructing `Mapper`. Image and pair order, pair configuration, camera setup,
+match order, and referenced keypoint, color, and descriptor rows are preserved.
+Feature and match files on disk are not rewritten. For a normally verified
+`matches.bin`, the stored records are the verified correspondences; raw records
+with configuration zero are preserved as well. The option is map-only and
+defaults off.
 
 ## Options
 

--- a/src/sfm/SfmConfig.h
+++ b/src/sfm/SfmConfig.h
@@ -111,6 +111,7 @@ struct SfmConfig {
 
     // Stage switches that are not a field of any stage's options.
     bool verify = true;                 // match: geometric verification
+    bool compact_unused_features = false;  // map: compact stored-match feature rows
     bool final_principal_point = true;  // one PP-free global BA at the end (D51)
     // Write the finished model in an upright, centred, unit-sized frame rather
     // than in whatever gauge the seed pair left it in (map/Orient.h).
@@ -283,6 +284,8 @@ struct SfmConfig {
     F(prefilter.ratio, "prefilter-ratio", CMD_AUTO | CMD_MATCH, Tier::Advanced, "matching", 0, 1,  \
       "", prefilter_ratio)                                                                         \
     /* ---- mapper ---- */                                                                         \
+    F(compact_unused_features, "compact-unused-features", CMD_MAP, Tier::Advanced, "mapper", 0,   \
+      0, "", compact_unused_features)                                                              \
     F(mapper.focal_trials, "focal-trials", CMD_AUTO | CMD_MAP, Tier::Advanced, "mapper", 0, 1000,  \
       "", focal_trials)                                                                            \
     F(mapper.refine_principal_point, "refine-principal-point", CMD_AUTO | CMD_MAP, Tier::Advanced, \

--- a/src/sfm/core/FeatureCompaction.h
+++ b/src/sfm/core/FeatureCompaction.h
@@ -1,0 +1,306 @@
+// Lossless in-memory removal of feature rows no stored match references.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "sfm/core/Features.h"
+#include "sfm/core/Matches.h"
+
+namespace sfm {
+
+using StoredFeatureIndex = decltype(FeatureMatch::idx1);
+static_assert(std::is_same<StoredFeatureIndex, uint32_t>::value,
+              "feature compaction must follow the stored match index type");
+
+constexpr StoredFeatureIndex kUnusedFeature =
+    std::numeric_limits<StoredFeatureIndex>::max();
+
+inline std::runtime_error compactionError(const std::string& what) {
+    return std::runtime_error("unused-feature compaction: " + what);
+}
+
+namespace feature_compaction_detail {
+
+// UINT32_MAX is the unused sentinel, so retained endpoint indices end one below it.
+inline StoredFeatureIndex checkedCompactIndex(uint64_t index) {
+    if (index >= uint64_t(kUnusedFeature))
+        throw compactionError("compact feature index " + std::to_string(index) +
+                              " exceeds the stored match index range");
+    return static_cast<StoredFeatureIndex>(index);
+}
+
+}  // namespace feature_compaction_detail
+
+struct FeatureCompactionStats {
+    uint64_t original_features = 0;
+    uint64_t compact_features = 0;
+    uint64_t correspondences = 0;
+    uint64_t pairs = 0;
+    uint64_t images = 0;
+    uint64_t zero_feature_images = 0;
+
+    uint64_t removedFeatures() const { return original_features - compact_features; }
+};
+
+struct FeatureCompactionPlan {
+    FeatureCompactionStats stats;
+
+    // Per original feature row: compact index, or UINT32_MAX when unreferenced.
+    std::vector<std::vector<StoredFeatureIndex>> old_to_new;
+    std::vector<uint32_t> compact_counts;
+
+    // Snapshots reject mutation between planning and endpoint remapping.
+    std::vector<std::string> image_names;
+    std::vector<uint32_t> image_feature_counts;
+    std::vector<Camera> cameras;
+    std::vector<uint32_t> camera_ids;
+    std::vector<uint8_t> focal_prior;
+    std::vector<uint32_t> pair_image1;
+    std::vector<uint32_t> pair_image2;
+    std::vector<int32_t> pair_config;
+    std::vector<size_t> pair_match_counts;
+};
+
+inline bool sameCameraExact(const Camera& a, const Camera& b) {
+    return a.id == b.id && a.width == b.width && a.height == b.height &&
+           a.model == b.model && a.fx == b.fx && a.fy == b.fy && a.cx == b.cx &&
+           a.cy == b.cy && a.k1 == b.k1 && a.k2 == b.k2 && a.p1 == b.p1 &&
+           a.p2 == b.p2 && a.k3 == b.k3 && a.k4 == b.k4 && a.sx1 == b.sx1 &&
+           a.sy1 == b.sy1 && a.pixel_scale == b.pixel_scale;
+}
+
+inline bool sameKeypointExact(const Keypoint& a, const Keypoint& b) {
+    return a.x == b.x && a.y == b.y && a.scale == b.scale &&
+           a.orientation == b.orientation && a.response == b.response;
+}
+
+inline FeatureCompactionPlan buildFeatureCompactionPlan(const MatchesDatabase& db) {
+    FeatureCompactionPlan plan;
+    plan.stats.images = db.images.size();
+    plan.stats.pairs = db.pairs.size();
+    plan.old_to_new.resize(db.images.size());
+    plan.compact_counts.resize(db.images.size(), 0);
+    plan.cameras = db.cameras;
+    plan.camera_ids = db.camera_ids;
+    plan.focal_prior = db.focal_prior;
+    plan.image_names.reserve(db.images.size());
+    plan.image_feature_counts.reserve(db.images.size());
+    plan.pair_image1.reserve(db.pairs.size());
+    plan.pair_image2.reserve(db.pairs.size());
+    plan.pair_config.reserve(db.pairs.size());
+    plan.pair_match_counts.reserve(db.pairs.size());
+
+    for (const ImageEntry& image : db.images) {
+        plan.stats.original_features += image.num_features;
+        plan.old_to_new[plan.image_names.size()].assign(image.num_features, kUnusedFeature);
+        plan.image_names.push_back(image.name);
+        plan.image_feature_counts.push_back(image.num_features);
+    }
+
+    for (size_t p = 0; p < db.pairs.size(); p++) {
+        const TwoViewMatches& pair = db.pairs[p];
+        if (pair.image1 >= db.images.size())
+            throw compactionError("pair " + std::to_string(p) + ": image1 " +
+                                  std::to_string(pair.image1) + " does not exist");
+        if (pair.image2 >= db.images.size())
+            throw compactionError("pair " + std::to_string(p) + ": image2 " +
+                                  std::to_string(pair.image2) + " does not exist");
+
+        plan.stats.correspondences += pair.matches.size();
+        plan.pair_image1.push_back(pair.image1);
+        plan.pair_image2.push_back(pair.image2);
+        plan.pair_config.push_back(pair.config);
+        plan.pair_match_counts.push_back(pair.matches.size());
+
+        std::vector<StoredFeatureIndex>& a = plan.old_to_new[pair.image1];
+        std::vector<StoredFeatureIndex>& b = plan.old_to_new[pair.image2];
+        for (size_t k = 0; k < pair.matches.size(); k++) {
+            const FeatureMatch& match = pair.matches[k];
+            if (match.idx1 >= a.size())
+                throw compactionError("pair " + std::to_string(p) + ", match " +
+                                      std::to_string(k) + ": idx1 " +
+                                      std::to_string(match.idx1) + " is outside image " +
+                                      std::to_string(pair.image1));
+            if (match.idx2 >= b.size())
+                throw compactionError("pair " + std::to_string(p) + ", match " +
+                                      std::to_string(k) + ": idx2 " +
+                                      std::to_string(match.idx2) + " is outside image " +
+                                      std::to_string(pair.image2));
+            a[match.idx1] = 0;
+            b[match.idx2] = 0;
+        }
+    }
+
+    for (size_t i = 0; i < plan.old_to_new.size(); i++) {
+        uint64_t next = 0;
+        for (StoredFeatureIndex& mapped : plan.old_to_new[i]) {
+            if (mapped == kUnusedFeature) continue;
+            mapped = feature_compaction_detail::checkedCompactIndex(next);
+            next++;
+        }
+        // Each input feature count is uint32_t, so next cannot exceed UINT32_MAX.
+        if (next > uint64_t(std::numeric_limits<uint32_t>::max()))
+            throw compactionError("compact feature count exceeds the file-format range");
+        plan.compact_counts[i] = static_cast<uint32_t>(next);
+        plan.stats.compact_features += next;
+        if (next == 0) plan.stats.zero_feature_images++;
+    }
+    return plan;
+}
+
+inline FeatureSet compactFeatureSet(FeatureSet input,
+                                    const std::vector<StoredFeatureIndex>& old_to_new,
+                                    uint32_t compact_count) {
+    if (input.keypoints.size() != old_to_new.size())
+        throw compactionError("feature-file count " +
+                              std::to_string(input.keypoints.size()) +
+                              " does not match matches.bin count " +
+                              std::to_string(old_to_new.size()));
+
+    const bool have_colors = input.hasColors();
+    if (!input.colors.empty() && !have_colors)
+        throw compactionError("feature colors are not one RGB row per keypoint");
+    const size_t descriptor_row = size_t(input.dim) * dtypeSize(input.dtype);
+    const bool have_descriptors = !input.descriptors.empty();
+    if (have_descriptors &&
+        input.descriptors.size() != input.keypoints.size() * descriptor_row)
+        throw compactionError("descriptor data is not one row per keypoint");
+
+    bool identity = compact_count == input.keypoints.size();
+    uint64_t expected = 0;
+    for (size_t old = 0; old < old_to_new.size(); old++) {
+        const StoredFeatureIndex mapped = old_to_new[old];
+        if (mapped == kUnusedFeature) {
+            identity = false;
+            continue;
+        }
+        if (mapped != feature_compaction_detail::checkedCompactIndex(expected++))
+            throw compactionError("old-to-new table is not stable and contiguous");
+        if (mapped != old) identity = false;
+    }
+    if (expected != compact_count)
+        throw compactionError("compact feature count does not match old-to-new table");
+    if (identity) return input;
+
+    FeatureSet out;
+    out.width = input.width;
+    out.height = input.height;
+    out.extract_width = input.extract_width;
+    out.extract_height = input.extract_height;
+    out.exif_focal = input.exif_focal;
+    out.exif_camera = input.exif_camera;
+    out.dim = input.dim;
+    out.dtype = input.dtype;
+    out.keypoints.reserve(compact_count);
+    if (have_colors) out.colors.reserve(size_t(compact_count) * 3);
+    if (have_descriptors) out.descriptors.reserve(size_t(compact_count) * descriptor_row);
+
+    for (size_t old = 0; old < old_to_new.size(); old++) {
+        if (old_to_new[old] == kUnusedFeature) continue;
+        out.keypoints.push_back(input.keypoints[old]);
+        if (have_colors)
+            out.colors.insert(out.colors.end(), input.colors.begin() + old * 3,
+                              input.colors.begin() + old * 3 + 3);
+        if (have_descriptors)
+            out.descriptors.insert(out.descriptors.end(),
+                                   input.descriptors.begin() + old * descriptor_row,
+                                   input.descriptors.begin() + (old + 1) * descriptor_row);
+
+        const StoredFeatureIndex now = old_to_new[old];
+        if (!sameKeypointExact(input.keypoints[old], out.keypoints[now]))
+            throw compactionError("keypoint data changed while compacting");
+        if (have_colors)
+            for (size_t c = 0; c < 3; c++)
+                if (input.colors[old * 3 + c] != out.colors[size_t(now) * 3 + c])
+                    throw compactionError("feature color changed while compacting");
+        if (have_descriptors)
+            for (size_t d = 0; d < descriptor_row; d++)
+                if (input.descriptors[old * descriptor_row + d] !=
+                    out.descriptors[size_t(now) * descriptor_row + d])
+                    throw compactionError("descriptor row changed while compacting");
+    }
+
+    if (out.count() != compact_count)
+        throw compactionError("compacted FeatureSet has the wrong feature count");
+    if (out.width != input.width || out.height != input.height ||
+        out.extract_width != input.extract_width || out.extract_height != input.extract_height ||
+        out.exif_focal != input.exif_focal || out.exif_camera != input.exif_camera ||
+        out.dim != input.dim || out.dtype != input.dtype)
+        throw compactionError("feature-set metadata changed while compacting");
+    return out;
+}
+
+inline void remapMatches(MatchesDatabase& db, const FeatureCompactionPlan& plan,
+                         const std::vector<FeatureSet>& compact_features) {
+    if (db.images.size() != plan.old_to_new.size() ||
+        db.images.size() != plan.compact_counts.size() ||
+        compact_features.size() != db.images.size())
+        throw compactionError("image count changed while applying the plan");
+    if (db.pairs.size() != plan.stats.pairs)
+        throw compactionError("pair count changed while applying the plan");
+    if (plan.image_names.size() != db.images.size() ||
+        plan.image_feature_counts.size() != db.images.size())
+        throw compactionError("image snapshot has the wrong size");
+    for (size_t i = 0; i < db.images.size(); i++) {
+        if (db.images[i].name != plan.image_names[i])
+            throw compactionError("image name or order changed while applying the plan");
+        if (db.images[i].num_features != plan.image_feature_counts[i])
+            throw compactionError("image feature count changed while applying the plan");
+    }
+    if (db.camera_ids != plan.camera_ids || db.focal_prior != plan.focal_prior ||
+        db.cameras.size() != plan.cameras.size())
+        throw compactionError("camera setup changed while applying the plan");
+    for (size_t i = 0; i < db.cameras.size(); i++)
+        if (!sameCameraExact(db.cameras[i], plan.cameras[i]))
+            throw compactionError("camera setup changed while applying the plan");
+    if (plan.pair_image1.size() != db.pairs.size() ||
+        plan.pair_image2.size() != db.pairs.size() ||
+        plan.pair_config.size() != db.pairs.size() ||
+        plan.pair_match_counts.size() != db.pairs.size())
+        throw compactionError("pair snapshot has the wrong size");
+
+    uint64_t correspondences = 0;
+    for (size_t p = 0; p < db.pairs.size(); p++) {
+        TwoViewMatches& pair = db.pairs[p];
+        if (pair.image1 != plan.pair_image1[p] || pair.image2 != plan.pair_image2[p] ||
+            pair.config != plan.pair_config[p] ||
+            pair.matches.size() != plan.pair_match_counts[p])
+            throw compactionError("pair identity, order, config or match count changed");
+        if (pair.image1 >= db.images.size() || pair.image2 >= db.images.size())
+            throw compactionError("pair " + std::to_string(p) + " has an invalid image id");
+
+        correspondences += pair.matches.size();
+        const std::vector<StoredFeatureIndex>& a = plan.old_to_new[pair.image1];
+        const std::vector<StoredFeatureIndex>& b = plan.old_to_new[pair.image2];
+        for (FeatureMatch& match : pair.matches) {
+            if (match.idx1 >= a.size() || match.idx2 >= b.size())
+                throw compactionError("match index changed before remapping");
+            const StoredFeatureIndex mapped1 = a[match.idx1];
+            const StoredFeatureIndex mapped2 = b[match.idx2];
+            if (mapped1 == kUnusedFeature || mapped2 == kUnusedFeature)
+                throw compactionError("a stored match endpoint was marked unused");
+            if (mapped1 >= compact_features[pair.image1].count() ||
+                mapped2 >= compact_features[pair.image2].count())
+                throw compactionError("a remapped match endpoint is out of bounds");
+            match.idx1 = mapped1;
+            match.idx2 = mapped2;
+        }
+    }
+    if (correspondences != plan.stats.correspondences)
+        throw compactionError("correspondence count changed while applying the plan");
+
+    for (size_t i = 0; i < db.images.size(); i++) {
+        if (compact_features[i].count() != plan.compact_counts[i])
+            throw compactionError("compacted FeatureSet count disagrees with its plan");
+        db.images[i].num_features = plan.compact_counts[i];
+    }
+}
+
+}  // namespace sfm

--- a/src/sfm/tests/sfm_feature_compaction_test.cpp
+++ b/src/sfm/tests/sfm_feature_compaction_test.cpp
@@ -1,0 +1,275 @@
+// Lossless feature compaction invariants and failure paths.
+#include <cstdio>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "sfm/core/FeatureCompaction.h"
+#include "sfm/tests/TestMain.h"
+
+using namespace sfm;
+
+static FeatureSet features(uint32_t count, float tag) {
+    FeatureSet set;
+    set.width = 1920;
+    set.height = 1080;
+    set.extract_width = 960;
+    set.extract_height = 540;
+    set.exif_focal = 733.25 + tag;
+    set.exif_camera = "camera-" + std::to_string((int)tag);
+    set.dim = 4;
+    set.dtype = DType::U8;
+    set.keypoints.resize(count);
+    set.descriptors.resize(size_t(count) * set.dim);
+    set.colors.resize(size_t(count) * 3);
+    for (uint32_t i = 0; i < count; i++) {
+        set.keypoints[i] = {tag + 10 * i, tag + 20 * i, tag + i, tag - i, tag + 2 * i};
+        for (uint32_t d = 0; d < set.dim; d++)
+            set.descriptors[size_t(i) * set.dim + d] = uint8_t(tag + 7 * i + d);
+        for (uint32_t c = 0; c < 3; c++)
+            set.colors[size_t(i) * 3 + c] = uint8_t(tag + 11 * i + c);
+    }
+    return set;
+}
+
+static MatchesDatabase database() {
+    MatchesDatabase db;
+    db.images = {{"cam0/a", 5}, {"cam1/b", 4}, {"cam0/unused", 3}};
+    db.cameras = {Camera::defaultFor(7, 1920, 1080, 900, CamModel::OpenCVFisheye)};
+    db.camera_ids = {7, 7, 7};
+    db.focal_prior = {1};
+
+    TwoViewMatches verified;
+    verified.image1 = 0;
+    verified.image2 = 1;
+    verified.config = 3;
+    verified.matches = {{1, 0, 1.0f}, {3, 1, 2.0f}, {4, 2, 3.0f}};
+
+    TwoViewMatches raw;
+    raw.image1 = 0;
+    raw.image2 = 1;
+    raw.config = 0;
+    raw.matches = {{1, 3, 4.0f}};
+    db.pairs = {verified, raw};
+    return db;
+}
+
+static std::vector<FeatureSet> featureSets() {
+    return {features(5, 10), features(4, 20), features(3, 30)};
+}
+
+static bool sameKeypoint(const Keypoint& a, const Keypoint& b) {
+    return a.x == b.x && a.y == b.y && a.scale == b.scale &&
+           a.orientation == b.orientation && a.response == b.response;
+}
+
+static bool sameCamera(const Camera& a, const Camera& b) {
+    return a.id == b.id && a.width == b.width && a.height == b.height &&
+           a.model == b.model && a.fx == b.fx && a.fy == b.fy && a.cx == b.cx &&
+           a.cy == b.cy && a.k1 == b.k1 && a.k2 == b.k2 && a.p1 == b.p1 &&
+           a.p2 == b.p2 && a.k3 == b.k3 && a.k4 == b.k4 && a.sx1 == b.sx1 &&
+           a.sy1 == b.sy1 && a.pixel_scale == b.pixel_scale;
+}
+
+static bool sameFeatureRow(const FeatureSet& a, uint32_t ai,
+                           const FeatureSet& b, uint32_t bi) {
+    if (!sameKeypoint(a.keypoints[ai], b.keypoints[bi])) return false;
+    for (size_t c = 0; c < 3; c++)
+        if (a.colors[size_t(ai) * 3 + c] != b.colors[size_t(bi) * 3 + c]) return false;
+    const size_t row = size_t(a.dim) * dtypeSize(a.dtype);
+    for (size_t d = 0; d < row; d++)
+        if (a.descriptors[size_t(ai) * row + d] != b.descriptors[size_t(bi) * row + d])
+            return false;
+    return true;
+}
+
+static bool throwsWith(const std::function<void()>& body, const std::string& text) {
+    try {
+        body();
+    } catch (const std::runtime_error& error) {
+        return std::string(error.what()).find(text) != std::string::npos;
+    }
+    return false;
+}
+
+static void check(bool condition, const char* message, int& fails) {
+    if (condition) return;
+    std::printf("  FAIL: %s\n", message);
+    fails++;
+}
+
+static std::vector<FeatureSet> compactAll(const std::vector<FeatureSet>& input,
+                                          const FeatureCompactionPlan& plan) {
+    std::vector<FeatureSet> compact(input.size());
+    for (size_t i = 0; i < input.size(); i++)
+        compact[i] = compactFeatureSet(input[i], plan.old_to_new[i], plan.compact_counts[i]);
+    return compact;
+}
+
+static int cmdFeatureCompactionTest(int, char**) {
+    int fails = 0;
+
+    MatchesDatabase db = database();
+    const MatchesDatabase original_db = db;
+    const std::vector<FeatureSet> original_features = featureSets();
+    FeatureCompactionPlan plan = buildFeatureCompactionPlan(db);
+    const uint32_t expected0[] = {kUnusedFeature, 0, kUnusedFeature, 1, 2};
+    for (uint32_t i = 0; i < 5; i++)
+        check(plan.old_to_new[0][i] == expected0[i], "stable feature remap", fails);
+    check(plan.compact_counts == std::vector<uint32_t>({3, 4, 0}) &&
+              plan.stats.original_features == 12 && plan.stats.compact_features == 7 &&
+              plan.stats.correspondences == 4 && plan.stats.pairs == 2 &&
+              plan.stats.zero_feature_images == 1,
+          "plan counts", fails);
+
+    std::vector<FeatureSet> compact = compactAll(original_features, plan);
+    remapMatches(db, plan, compact);
+
+    check(db.images.size() == original_db.images.size() &&
+              db.images[2].name == "cam0/unused" && compact[2].count() == 0 &&
+              db.images[2].num_features == 0 && compact[2].width == 1920 &&
+              compact[2].height == 1080 && compact[2].exif_camera == "camera-30",
+          "zero-active image and metadata", fails);
+    check(db.pairs.size() == original_db.pairs.size(), "pair count", fails);
+    for (size_t p = 0; p < db.pairs.size(); p++) {
+        check(db.pairs[p].image1 == original_db.pairs[p].image1 &&
+                  db.pairs[p].image2 == original_db.pairs[p].image2 &&
+                  db.pairs[p].config == original_db.pairs[p].config &&
+                  db.pairs[p].matches.size() == original_db.pairs[p].matches.size(),
+              "pair identity, config and correspondence count", fails);
+        for (size_t k = 0; k < db.pairs[p].matches.size(); k++) {
+            const FeatureMatch& old = original_db.pairs[p].matches[k];
+            const FeatureMatch& now = db.pairs[p].matches[k];
+            check(now.distance == old.distance &&
+                      sameFeatureRow(original_features[db.pairs[p].image1], old.idx1,
+                                     compact[db.pairs[p].image1], now.idx1) &&
+                      sameFeatureRow(original_features[db.pairs[p].image2], old.idx2,
+                                     compact[db.pairs[p].image2], now.idx2),
+                  "feature-row and endpoint identity", fails);
+        }
+    }
+    check(db.pairs[1].config == 0 && db.pairs[1].matches[0].idx1 == 0 &&
+              db.pairs[1].matches[0].idx2 == 3,
+          "config-zero stored match", fails);
+    check(db.camera_ids == original_db.camera_ids &&
+              db.focal_prior == original_db.focal_prior &&
+              db.cameras.size() == original_db.cameras.size() &&
+              sameCamera(db.cameras[0], original_db.cameras[0]),
+          "camera setup", fails);
+
+    {
+        MatchesDatabase all;
+        all.images = {{"a", 3}, {"b", 3}};
+        TwoViewMatches pair;
+        pair.image1 = 0;
+        pair.image2 = 1;
+        pair.config = 1;
+        pair.matches = {{0, 2, 0}, {1, 1, 0}, {2, 0, 0}};
+        all.pairs = {pair};
+        FeatureCompactionPlan all_plan = buildFeatureCompactionPlan(all);
+        FeatureSet before = features(3, 50);
+        FeatureSet after =
+            compactFeatureSet(before, all_plan.old_to_new[0], all_plan.compact_counts[0]);
+        bool same = after.keypoints.size() == before.keypoints.size() &&
+                    after.descriptors == before.descriptors && after.colors == before.colors;
+        for (uint32_t i = 0; same && i < before.count(); i++)
+            same = sameKeypoint(before.keypoints[i], after.keypoints[i]);
+        check(same, "all-used input identity", fails);
+    }
+
+    auto badEndpoint = [&](bool second) {
+        MatchesDatabase bad;
+        bad.images = {{"a", 2}, {"b", 2}};
+        TwoViewMatches pair;
+        pair.image1 = 0;
+        pair.image2 = 1;
+        pair.matches = {second ? FeatureMatch{0, 2, 0} : FeatureMatch{2, 0, 0}};
+        bad.pairs = {pair};
+        return bad;
+    };
+    check(throwsWith([&] { buildFeatureCompactionPlan(badEndpoint(false)); }, "idx1 2"),
+          "invalid idx1", fails);
+    check(throwsWith([&] { buildFeatureCompactionPlan(badEndpoint(true)); }, "idx2 2"),
+          "invalid idx2", fails);
+
+    auto badImage = [&](bool second) {
+        MatchesDatabase bad;
+        bad.images = {{"a", 1}, {"b", 1}};
+        TwoViewMatches pair;
+        pair.image1 = second ? 0 : 2;
+        pair.image2 = second ? 2 : 1;
+        pair.matches = {{0, 0, 0}};
+        bad.pairs = {pair};
+        return bad;
+    };
+    check(throwsWith([&] { buildFeatureCompactionPlan(badImage(false)); }, "image1 2"),
+          "invalid image1", fails);
+    check(throwsWith([&] { buildFeatureCompactionPlan(badImage(true)); }, "image2 2"),
+          "invalid image2", fails);
+
+    check(throwsWith(
+              [&] {
+                  feature_compaction_detail::checkedCompactIndex(uint64_t(kUnusedFeature));
+              },
+              "stored match index range"),
+          "uint32 endpoint boundary", fails);
+
+    check(throwsWith(
+              [&] { compactFeatureSet(features(2, 1), {0}, 1); },
+              "feature-file count"),
+          "feature-file count mismatch", fails);
+    check(throwsWith(
+              [&] {
+                  FeatureSet malformed = features(2, 1);
+                  malformed.colors.pop_back();
+                  compactFeatureSet(std::move(malformed), {0, 1}, 2);
+              },
+              "feature colors"),
+          "malformed color rows", fails);
+    check(throwsWith(
+              [&] {
+                  FeatureSet malformed = features(2, 1);
+                  malformed.descriptors.pop_back();
+                  compactFeatureSet(std::move(malformed), {0, 1}, 2);
+              },
+              "descriptor data"),
+          "malformed descriptor rows", fails);
+
+    auto rejectsMutation = [&](const std::function<void(MatchesDatabase&)>& mutate,
+                               const std::string& expected) {
+        MatchesDatabase changed = database();
+        FeatureCompactionPlan snapshot = buildFeatureCompactionPlan(changed);
+        std::vector<FeatureSet> changed_features = compactAll(featureSets(), snapshot);
+        mutate(changed);
+        return throwsWith([&] { remapMatches(changed, snapshot, changed_features); }, expected);
+    };
+    check(rejectsMutation([](MatchesDatabase& value) { value.images[0].num_features++; },
+                          "feature count changed"),
+          "feature-count snapshot", fails);
+    check(rejectsMutation([](MatchesDatabase& value) { value.cameras[0].fx += 1; },
+                          "camera setup changed"),
+          "camera snapshot", fails);
+    check(rejectsMutation([](MatchesDatabase& value) { value.pairs[0].image1 = 2; },
+                          "pair identity"),
+          "pair identity snapshot", fails);
+    check(rejectsMutation([](MatchesDatabase& value) { std::swap(value.pairs[0], value.pairs[1]); },
+                          "pair identity"),
+          "pair-order snapshot", fails);
+    check(rejectsMutation([](MatchesDatabase& value) { value.pairs.pop_back(); },
+                          "pair count changed"),
+          "pair-count snapshot", fails);
+    check(rejectsMutation([](MatchesDatabase& value) { value.pairs[0].config = 9; },
+                          "pair identity"),
+          "pair-config snapshot", fails);
+    check(rejectsMutation([](MatchesDatabase& value) { value.pairs[0].matches.pop_back(); },
+                          "pair identity"),
+          "correspondence-count snapshot", fails);
+
+    std::printf("feature compaction: 12 -> 7 features, 4 stored correspondences retained\n");
+    std::printf("%s\n", fails == 0 ? "PASS" : "FAIL");
+    return fails == 0 ? 0 : 1;
+}
+
+int main() { return sfmTestMain(0, nullptr, cmdFeatureCompactionTest); }

--- a/src/sfm/tests/sfm_map_test.cpp
+++ b/src/sfm/tests/sfm_map_test.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "sfm/core/FeatureCompaction.h"
 #include "sfm/core/Model.h"
 #include "sfm/map/Bundle.h"
 #include "sfm/map/Assemble.h"
@@ -103,6 +104,16 @@ int cmdMapSelftest(int argc, char** argv) {
             if (tv.matches.size() >= 15) db.pairs.push_back(std::move(tv));
         }
 
+    MatchesDatabase compact_db = db;
+    std::vector<FeatureSet> compact_feats(feats.size());
+    {
+        FeatureCompactionPlan plan = buildFeatureCompactionPlan(compact_db);
+        for (size_t i = 0; i < feats.size(); i++)
+            compact_feats[i] =
+                compactFeatureSet(feats[i], plan.old_to_new[i], plan.compact_counts[i]);
+        remapMatches(compact_db, plan, compact_feats);
+    }
+
     Mapper mapper(db, feats, opt);
     // The synthetic scene is one connected component, so this must stay a
     // single model -- more than one would mean the mapper split a graph that
@@ -116,6 +127,44 @@ int cmdMapSelftest(int argc, char** argv) {
            rec.points3D.size(), models.size());
     if (reg < (uint32_t)M) { printf("  FAIL: not all images registered\n"); fails++; }
     if (models.size() != 1) { printf("  FAIL: connected scene split into models\n"); fails++; }
+
+    Mapper compact_mapper(compact_db, compact_feats, opt);
+    std::vector<Reconstruction> compact_models = compact_mapper.run();
+    bool compact_equivalent = !compact_models.empty() && compact_models.size() == models.size();
+    const Reconstruction* compact_rec = compact_models.empty() ? nullptr : &compact_models.front();
+    if (compact_equivalent)
+        compact_equivalent = compact_rec->numRegistered() == rec.numRegistered() &&
+                             compact_rec->points3D.size() == rec.points3D.size() &&
+                             countObservations(*compact_rec) == countObservations(rec);
+    if (compact_equivalent) {
+        for (const auto& image : rec.images) {
+            auto found = compact_rec->images.find(image.first);
+            if (found == compact_rec->images.end() ||
+                found->second.registered != image.second.registered) {
+                compact_equivalent = false;
+                break;
+            }
+        }
+    }
+    if (compact_equivalent) {
+        for (const auto& camera : rec.cameras) {
+            auto found = compact_rec->cameras.find(camera.first);
+            if (found == compact_rec->cameras.end() ||
+                std::fabs(found->second.fx - camera.second.fx) > 1e-9 ||
+                std::fabs(found->second.fy - camera.second.fy) > 1e-9 ||
+                std::fabs(found->second.cx - camera.second.cx) > 1e-9 ||
+                std::fabs(found->second.cy - camera.second.cy) > 1e-9) {
+                compact_equivalent = false;
+                break;
+            }
+        }
+    }
+    printf("  unused-feature compaction A/B: %s (%u images, %zu points, %zu obs)\n",
+           compact_equivalent ? "equivalent" : "BAD",
+           compact_rec ? compact_rec->numRegistered() : 0,
+           compact_rec ? compact_rec->points3D.size() : 0,
+           compact_rec ? countObservations(*compact_rec) : 0);
+    if (!compact_equivalent) fails++;
 
     // Relative rotations are invariant to the global similarity gauge.
     double maxRelErr = 0;


### PR DESCRIPTION
## Summary

Add an opt-in SfM mapping pass that losslessly compacts feature storage before
Mapper construction. Feature rows not referenced by any stored match record are
removed, and every stored match endpoint is remapped to the retained row's new
index.

The option is disabled by default and is exposed only by `sfm map`.

## Motivation

Large feature databases can contain many extracted features that are not
referenced by the matches consumed by the mapper. Keeping those unused
keypoint, color, and descriptor rows resident increases memory use without
adding mapper correspondences.

Compacting the loaded feature sets before camera setup and Mapper construction
reduces this storage while preserving the stored match graph.

## Implementation

- Scan every stored match record to identify referenced feature rows per image.
- Build a stable old-index-to-new-index map in original feature order.
- Copy only referenced rows, preserving keypoints (including response), optional
  RGB values, optional descriptors, and image metadata.
- Remap both endpoints of every stored correspondence.
- Validate endpoint and image bounds plus image, camera, pair, configuration,
  and correspondence-count snapshots.
- Use a checked 64-bit assignment counter before converting to the stored
  `uint32_t` endpoint type.
- Release the temporary dense maps before camera setup and Mapper construction.

For a normally verified `matches.bin`, the stored records are the verified
correspondences. Raw stored records with `config == 0` are preserved as well;
the pass does not filter or reinterpret pair configuration.

## Scope

This change does not rank or cap features, pairs, or matches. It preserves every
stored image pair and correspondence, changing only feature-row storage and the
corresponding endpoint indices.

It does not change mapper logic, bundle adjustment, camera models or parameters,
Bottom-up scheduling, model assembly, or merge behavior. It does not rewrite
feature or match files; compaction is performed entirely in memory.

## Validation

### Tests on current master

The full Vulkan CLI build completed with the default SfM shader matrix. All
locally available SfM tests passed:

- `sfm_cholesky_test`
- `sfm_feature_compaction_test`
- `sfm_geometry_test`
- `sfm_map_test`
- `sfm_mask_test`
- `sfm_merge_test`
- `sfm_sift_test`

The synthetic Mapper A/B produced the same one-model reconstruction with 8/8
registered images, 179 points, and 1,267 observations.

### Existing real-data A/B validation

On a 402-image real subset using the Flat mapper, compaction removed 58.68% of
feature rows. Peak RSS was about 1.50 GiB versus about 2.07–2.08 GiB for two
comparable reference runs. Registered-image, point, observation, and
reprojection statistics remained within the cross-process spread observed
between the two reference runs.

On an 802-image real subset using the Bottom-up mapper, compaction removed
73.11% of feature rows. Peak RSS decreased from 5,645,344 KiB to 3,342,184 KiB
(-40.80%), and wall time changed from 5:20.82 to 4:28.69. The reference and
compact runs registered 768 and 769 unique images; point count differed by
-0.53% and exported observations by -0.57%. `joint_after_atoms` ran, and no
invalid point2D indices, crashes, or assertions were observed.

These real reconstruction results are not claimed to be bitwise deterministic;
they are evaluated against the observed cross-process variation.

### Large-scale memory/completion validation

A 9,276-image Bottom-up mapping run compacted 274,016,632 feature rows to
40,362,541, removing 233,654,091 rows (85.27%) while retaining 152,845 stored
image pairs and 58,703,402 stored correspondences. The mapper completed with
return code 0 in 38:25.84, with 17.08 GiB peak process RSS, 22.91 GiB peak
target `memory.current`, no swap use, and no memory PSI. `joint_after_atoms`
completed.

This full-scale result is a memory/completion validation, not a reconstruction-
quality A/B: the available older uncompact run used a different mapper mode.
Bottom-up model fragmentation is a separate issue and is not addressed here.

## Usage

```bash
spirula sfm map matches.bin features/ -o sparse/ --compact-unused-features
```

The option defaults to off and currently applies only to the explicit `sfm map`
command.

## Notes / limitations

- The pass uses one temporary `uint32_t` old-to-new entry per original feature
  row. This plan is released before Mapper construction.
- The current option is not exposed by `sfm auto`.
- The change does not address mapper selection, reconstruction fragmentation,
  model assembly, or large-scale SfM quality.