### PR TITLE
Naive progress changes: percentage, elapsed | ETA, and an end-of-run summary

### DIFF
--- a/src/app/TrainerCore.cpp
+++ b/src/app/TrainerCore.cpp
@@ -489,6 +489,18 @@ std::string train_config_unsupported(const TrainConfig& c) {
     return {};
 }
 
+std::string format_duration(double seconds) {
+    if (seconds < 0) return "--:--";
+    int t = (int)(seconds + 0.5);
+    char buf[32];
+    if (t >= 3600)
+        std::snprintf(buf, sizeof buf, "%d:%02d:%02d", t / 3600, (t / 60) % 60,
+                      t % 60);
+    else
+        std::snprintf(buf, sizeof buf, "%d:%02d", t / 60, t % 60);
+    return buf;
+}
+
 // Unported-feature guards: fail early rather than ignore a flag.
 void TrainerSession::check_config() {
     if (std::string what = train_config_unsupported(cfg); !what.empty())
@@ -889,6 +901,21 @@ double TrainerSession::elapsed_seconds() const {
     return std::max(0.0, s);
 }
 
+double TrainerSession::avg_step_latency() const {
+    std::lock_guard<std::mutex> lk(_progress_mutex);
+    if (_step_latencies.empty()) return -1.0;
+    double sum = 0.0;
+    for (double v : _step_latencies) sum += v;
+    return sum / (double)_step_latencies.size();
+}
+
+double TrainerSession::eta_seconds() const {
+    const double avg = avg_step_latency();
+    const int step = cur_step.load();
+    if (avg < 0.0 || step <= 0) return -1.0;
+    return std::max(0, cfg.num_iterations - step) * avg;
+}
+
 void TrainerSession::train(const TrainerCallbacks& cb) {
     {
         std::lock_guard<std::mutex> lk(_time_mutex);
@@ -983,17 +1010,10 @@ void TrainerSession::train(const TrainerCallbacks& cb) {
 std::string TrainerSession::progress_json() {
     int step = cur_step.load();
     double elapsed = elapsed_seconds();
-    double avg = 0.0;
-    size_t nlat = 0;
-    {
-        std::lock_guard<std::mutex> lk(_progress_mutex);
-        for (double v : _step_latencies) avg += v;
-        nlat = _step_latencies.size();
-    }
-    if (nlat) avg /= (double)nlat;
+    double avg = avg_step_latency();
+    double eta = eta_seconds();
     char buf[256];
-    if (nlat && step > 0) {
-        double eta = (cfg.num_iterations - step) * avg;
+    if (eta >= 0.0) {
         std::snprintf(buf, sizeof buf,
             "{\"step\": %d, \"total_steps\": %d, \"elapsed_time\": %.3f, "
             "\"eta\": %.3f, \"latency_ms\": %.3f, \"paused\": %s}",

--- a/src/app/TrainerCore.cpp
+++ b/src/app/TrainerCore.cpp
@@ -1005,6 +1005,11 @@ void TrainerSession::train(const TrainerCallbacks& cb) {
         save_checkpoint(step);
         log(lfmt(lmsg::checkpoint_saved, {fs::absolute(out_dir).string()}));
     }
+
+    // Steps THIS run, not cur_step: a resumed run's clock starts here too, and
+    // a count that included the checkpoint's steps would not match the time.
+    log(lfmt(lmsg::train_finished, {cur_step.load() - start_step,
+                                    format_duration(training_time_s)}));
 }
 
 std::string TrainerSession::progress_json() {

--- a/src/app/TrainerCore.h
+++ b/src/app/TrainerCore.h
@@ -121,6 +121,9 @@ std::string train_config_unsupported(const TrainConfig& c);
 // TrainerSession
 // ===========================================================================
 
+// "m:ss", or "h:mm:ss" past an hour; negative (not known yet) is "--:--".
+std::string format_duration(double seconds);
+
 struct TrainerProgress {
     int step = 0;              // 0-based step that just finished
     int total_steps = 0;
@@ -232,6 +235,10 @@ public:
     // train() starts, frozen once it returns.
     double elapsed_seconds() const;
 
+    // Remaining wall clock over the last 100 steps' average, or -1 before
+    // the first step lands.
+    double eta_seconds() const;
+
     // The /progress response body.
     std::string progress_json();
 
@@ -247,12 +254,15 @@ private:
     void pause_clock_start();
     void pause_clock_stop();
 
+    // Seconds per step over the window, or -1 while it is empty.
+    double avg_step_latency() const;
+
     mutable std::mutex _time_mutex;                        // guards the clock
     std::chrono::steady_clock::time_point _start_time{};   // {} = not started
     std::chrono::steady_clock::time_point _end_time{};     // {} = running
     std::chrono::steady_clock::time_point _pause_start{};  // {} = not paused
     double _paused_s = 0.0;
-    std::mutex _progress_mutex;            // guards the latency window
+    mutable std::mutex _progress_mutex;    // guards the latency window
     std::deque<double> _step_latencies;    // last 100, seconds
 };
 

--- a/src/app/cli/main.cpp
+++ b/src/app/cli/main.cpp
@@ -496,17 +496,18 @@ int spirula_train_main(int argc, char** argv) {
         TrainerCallbacks cb;
         cb.on_step = [&](const TrainerProgress& p) {
             if (p.step % 100 == 0 || p.step == p.total_steps - 1) {
-                double dt = session.elapsed_seconds();
-                // The step and the elapsed time are padded/rounded here rather
-                // than by the message, so the numbers keep their column while
-                // the words around them change length per language.
-                char step[16], secs[16];
-                std::snprintf(step, sizeof step, "%6d", p.step);
-                std::snprintf(secs, sizeof secs, "%.1f", dt);
+                // step + 1 is steps completed, as in the GUI. Both numbers
+                // are padded here, not by the message, so they keep their
+                // column while the words around them change length.
+                char step[16], pct[16];
+                std::snprintf(step, sizeof step, "%6d", p.step + 1);
+                std::snprintf(pct, sizeof pct, "%3d",
+                              100 * (p.step + 1) / p.total_steps);
                 std::printf("%s", format(cmsg::train_step_line,
-                                         {step, p.total_steps,
+                                         {step, p.total_steps, pct,
                                           (long long)p.num_splats,
-                                          secs}).c_str());
+                                          format_duration(session.elapsed_seconds()),
+                                          format_duration(session.eta_seconds())}).c_str());
                 for (const char* k : {"rgb_loss", "ssim", "psnr"}) {
                     auto it = p.losses.find(k);
                     if (it != p.losses.end()) std::printf("  %s=%.4g", k, it->second);

--- a/src/app/gui/GuiApp.cpp
+++ b/src/app/gui/GuiApp.cpp
@@ -44,6 +44,7 @@ namespace fld = spirula::i18n::msg::field;
 namespace dmsg = spirula::i18n::msg::dataset;
 namespace gmsg = spirula::i18n::msg::geometry;
 using spirula::i18n::Msg;
+using spirula::format_duration;
 
 namespace gui {
 
@@ -57,15 +58,6 @@ const ImVec4 kDim(0.6f, 0.6f, 0.6f, 1.0f);
 std::string format_gib(uint64_t bytes) {
     char buf[32];
     std::snprintf(buf, sizeof buf, "%.2f", (double)bytes / (1024.0 * 1024.0 * 1024.0));
-    return buf;
-}
-
-std::string format_duration(double s) {
-    if (s < 0) return "--:--";
-    int t = (int)(s + 0.5);
-    char buf[32];
-    if (t >= 3600) std::snprintf(buf, sizeof buf, "%d:%02d:%02d", t/3600, (t/60)%60, t%60);
-    else           std::snprintf(buf, sizeof buf, "%d:%02d", t/60, t%60);
     return buf;
 }
 
@@ -5159,7 +5151,7 @@ void GuiApp::draw_status_strip() {
     if (ph == TrainRunner::Phase::Training && p.total_steps > 0) {
         float frac = (float)(p.step + 1) / (float)p.total_steps;
         ui::ProgressBar(frac, ImVec2(-8, 0), msg::status_step,
-                        {p.step + 1, p.total_steps});
+                        {p.step + 1, p.total_steps, (int)(frac * 100.0f)});
         char ms[32];
         std::snprintf(ms, sizeof ms, "%.0f", p.step_latency * 1000.0);
         ui::Text(_runner.paused() ? msg::status_rate_paused : msg::status_rate,

--- a/src/i18n/catalog/Cli.h
+++ b/src/i18n/catalog/Cli.h
@@ -463,22 +463,23 @@ SS_MSG(viewer_at,
        "порт: ssh -L {1}:localhost:{2} <host>)"),
     TR("Görüntüleyici http://0.0.0.0:{0}/ adresinde (uzak makinelerde bağlantı "
        "noktasını yönlendirin: ssh -L {1}:localhost:{2} <host>)"));
-// {0} and {1} are already padded to a fixed width by the caller, so the
+// {0} and {2} are already padded to a fixed width by the caller, so the
 // numbers stay in a column while the words around them change length.
+// {4}|{5} is elapsed|remaining, in the same words as the GUI status strip.
 SS_MSG(train_step_line,
-    EN("step {0}/{1}  splats {2}  [{3}s]"),
-    JA("ステップ {0}/{1}  スプラット {2}  [{3}秒]"),
-    ZH_HANS("步 {0}/{1}  泼溅 {2}  [{3} 秒]"),
-    ZH_HANT("步 {0}/{1}  潑濺 {2}  [{3} 秒]"),
-    KO("스텝 {0}/{1}  스플랫 {2}  [{3}초]"),
-    DE("Schritt {0}/{1}  Splats {2}  [{3}s]"),
-    FR("étape {0}/{1}  splats {2}  [{3}s]"),
-    ES("paso {0}/{1}  splats {2}  [{3}s]"),
-    PT("passo {0}/{1}  splats {2}  [{3}s]"),
-    IT("passo {0}/{1}  splat {2}  [{3}s]"),
-    NL("stap {0}/{1}  splats {2}  [{3}s]"),
-    RU("шаг {0}/{1}  сплатов {2}  [{3}с]"),
-    TR("adım {0}/{1}  splat {2}  [{3}sn]"));
+    EN("step {0}/{1} ({2}%)  splats {3}  [elapsed {4} | ETA {5}]"),
+    JA("ステップ {0}/{1} ({2}%)  スプラット {3}  [経過 {4} | 残り {5}]"),
+    ZH_HANS("步 {0}/{1} ({2}%)  泼溅 {3}  [已用 {4} | 剩余 {5}]"),
+    ZH_HANT("步 {0}/{1} ({2}%)  潑濺 {3}  [已用 {4} | 剩餘 {5}]"),
+    KO("스텝 {0}/{1} ({2}%)  스플랫 {3}  [경과 {4} | 남은 시간 {5}]"),
+    DE("Schritt {0}/{1} ({2}%)  Splats {3}  [Laufzeit {4} | Restzeit {5}]"),
+    FR("étape {0}/{1} ({2} %)  splats {3}  [écoulé {4} | reste {5}]"),
+    ES("paso {0}/{1} ({2}%)  splats {3}  [lleva {4} | faltan {5}]"),
+    PT("passo {0}/{1} ({2}%)  splats {3}  [decorrido {4} | faltam {5}]"),
+    IT("passo {0}/{1} ({2}%)  splat {3}  [trascorso {4} | mancano {5}]"),
+    NL("stap {0}/{1} ({2}%)  splats {3}  [verstreken {4} | nog {5}]"),
+    RU("шаг {0}/{1} ({2}%)  сплатов {3}  [прошло {4} | осталось {5}]"),
+    TR("adım {0}/{1} (%{2})  splat {3}  [geçen {4} | kalan {5}]"));
 SS_MSG(train_done_viewer,
     EN("Training complete. Viewer still running -- press Ctrl-C to exit."),
     JA("学習が完了しました。ビューアはまだ動いています。終了するには Ctrl-C を"

--- a/src/i18n/catalog/Gui.h
+++ b/src/i18n/catalog/Gui.h
@@ -1621,11 +1621,13 @@ SS_MSG(stop_and_save_help,
 // ---- status strip ----
 
 SS_MSG(status_step,
-    EN("step {0} / {1}"), JA("ステップ {0} / {1}"), ZH_HANS("第 {0} / {1} 步"),
-    ZH_HANT("第 {0} / {1} 步"), KO("{0} / {1} 단계"), DE("Schritt {0} / {1}"),
-    FR("étape {0} / {1}"), ES("paso {0} / {1}"), PT("passo {0} / {1}"),
-    IT("passo {0} / {1}"), NL("stap {0} / {1}"), RU("шаг {0} / {1}"),
-    TR("adım {0} / {1}"));
+    EN("step {0} / {1}  ({2}%)"), JA("ステップ {0} / {1}  ({2}%)"),
+    ZH_HANS("第 {0} / {1} 步  ({2}%)"), ZH_HANT("第 {0} / {1} 步  ({2}%)"),
+    KO("{0} / {1} 단계  ({2}%)"), DE("Schritt {0} / {1}  ({2}%)"),
+    FR("étape {0} / {1}  ({2} %)"), ES("paso {0} / {1}  ({2}%)"),
+    PT("passo {0} / {1}  ({2}%)"), IT("passo {0} / {1}  ({2}%)"),
+    NL("stap {0} / {1}  ({2}%)"), RU("шаг {0} / {1}  ({2}%)"),
+    TR("adım {0} / {1}  (%{2})"));
 
 SS_MSG(status_rate,
     EN("{0} ms/step   elapsed {1}   ETA {2}   splats: {3}"),

--- a/src/i18n/catalog/Log.h
+++ b/src/i18n/catalog/Log.h
@@ -1056,6 +1056,24 @@ SS_MSG(checkpoint_saved,
     RU("Контрольная точка сохранена: {0}"),
     TR("Denetim noktası şuraya kaydedildi: {0}"));
 
+// Labelled rather than inflected ("Steps: 3", not "3 steps") -- see
+// src/i18n/README.md. Steps counts what THIS run did, so it pairs with a
+// time that also excludes whatever a resumed checkpoint already had.
+SS_MSG(train_finished,
+    EN("Training complete. Steps: {0}   Time: {1}"),
+    JA("学習が完了しました。ステップ: {0}   所要時間: {1}"),
+    ZH_HANS("训练完成。步数：{0}   用时：{1}"),
+    ZH_HANT("訓練完成。步數：{0}   用時：{1}"),
+    KO("학습이 끝났습니다. 스텝: {0}   소요 시간: {1}"),
+    DE("Training abgeschlossen. Schritte: {0}   Zeit: {1}"),
+    FR("Entraînement terminé. Étapes : {0}   Durée : {1}"),
+    ES("Entrenamiento terminado. Pasos: {0}   Tiempo: {1}"),
+    PT("Treinamento concluído. Passos: {0}   Tempo: {1}"),
+    IT("Addestramento completato. Passi: {0}   Tempo: {1}"),
+    NL("Training klaar. Stappen: {0}   Tijd: {1}"),
+    RU("Обучение завершено. Шагов: {0}   Время: {1}"),
+    TR("Eğitim tamamlandı. Adım: {0}   Süre: {1}"));
+
 SS_MSG(eval_split_empty,
     EN("Eval: the eval split is empty; nothing to score."),
     JA("評価: 評価用の分割が空です。採点するものがありません。"),


### PR DESCRIPTION
Three small changes to the progress output. Nothing touches training.

- The step counter shows a percentage: step 1200 / 30000  (4%) in the GUI and the CLI.
- The CLI prints remaining time, not just elapsed: [elapsed 0:43 | ETA 10:44]. The ETA was already computed for the GUI status strip and progress, it just never reached the terminal.
- One line when a run ends: Training complete. Steps: 30000   Time: 12:00. It comes from train(), so stdout and the GUI log panel both get it.

One behaviour change worth flagging: the CLI counted steps from 0, so its last line read step 29999/30000. It now matches the GUI and ends on 30000/30000 (100%).

All 13 languages filled in (thank you Codex :) )