### PR TITLE
Support warm-starting training from a trained splat PLY

### DIFF
--- a/src/app/README.md
+++ b/src/app/README.md
@@ -323,6 +323,33 @@ in `core/Tensor.h` — those are `__device__` functions, but `__device__` is an
 empty macro in host translation units, so the host path calls the same code
 the kernels do rather than a copy of it.
 
+## Warm start
+
+`--init-ply <file.ply|run_dir|step-*.ckpt>` seeds the run from an
+already-trained 3DGS PLY instead of the dataset's point cloud
+(`seed_splats_from_ply()` in `TrainerCore.cpp`). Everything the file carries —
+means, scales, rotations, opacities, DC and SH — goes straight into
+`set_data_3dgs()`; only the layout is re-fitted to this run. Splats past
+`cap_max` are dropped by lowest opacity, the SH past the DC is truncated or
+zero-padded to `sh_degree`, `relative_scale` scales the means and shifts the
+log-scales, and the DC converts to the splat gamut when
+`convert_initial_point_cloud_color` is on (the view-dependent terms ride an
+encoded curve and cannot follow, so they come across as they are).
+
+`--init-ply-add-points` adds the dataset's point cloud **on top** rather than
+replacing it: the PLY goes in first and `append_point_seeds()` fills what is
+left up to `cap_max` with an ordinary `seed_splats()` over the cloud. It is the
+flag for a dataset that has grown since that model was trained; where the two
+overlap the extra splats are redundant and refinement prunes them.
+
+This is **not** a resume: the step counter starts at 0, the optimizer starts
+empty and the refinement schedule runs from the beginning. The PLY has to be in
+this run's training frame — same dataset, same scene settings
+(`orientation_method`, `center_method`, `auto_scale_poses`, `train_frame`,
+`relative_scale`) — because nothing registers it. When both are given
+`--resume` wins with a warning, since a resumed run's `config.json` carries the
+original `--init-ply` too.
+
 ## Eval
 
 Runs after training when `eval_mode != "all"` and the eval split is non-empty.

--- a/src/app/TrainerCore.cpp
+++ b/src/app/TrainerCore.cpp
@@ -4,6 +4,7 @@
 #include "app/EvalMetrics.h"
 #include "checkpoint/Adapt.h"
 #include "checkpoint/Resume.h"
+#include "checkpoint/SplatPly.h"
 #include "config/TrainConfigJson.h"
 #include "core/ColorSpace.h"
 #include "core/ExrImage.h"
@@ -236,6 +237,126 @@ SeedSplats seed_splats(const ColmapPoints3D& pts, const TrainConfig& cfg,
             s.features_dc[i*3 + d] = (col[d] - 0.5f) / 0.28209479177387814f;
     }
     return s;
+}
+
+SeedSplats seed_splats_from_ply(const std::string& path, const TrainConfig& cfg,
+                                const ColorResolution& color) {
+    constexpr float kSHC0 = 0.28209479177387814f;  // band-0 SH, colour <-> DC
+    if (!is_splat_ply(path))
+        throw std::runtime_error(
+            path + ": not a 3D Gaussian Splatting PLY (no opacity / scale / rot "
+            "properties). A plain point cloud is a dataset's seed cloud, not an "
+            "--init-ply.");
+    SplatCloud src = read_splat_ply(path, cfg.sh_degree > 0);
+    if (src.num == 0) throw std::runtime_error(path + ": no splats in file");
+
+    std::vector<int64_t> pick((size_t)src.num);
+    std::iota(pick.begin(), pick.end(), (int64_t)0);
+    if (src.num > cfg.cap_max) {
+        // Faintest out first, as checkpoint adaptation does (checkpoint/Adapt.h).
+        std::partial_sort(pick.begin(), pick.begin() + cfg.cap_max, pick.end(),
+                          [&](int64_t a, int64_t b) {
+                              return src.opacities[(size_t)a] >
+                                     src.opacities[(size_t)b];
+                          });
+        pick.resize((size_t)cfg.cap_max);
+    }
+
+    const int64_t num = (int64_t)pick.size();
+    const int64_t cap = cfg.preallocate_splat_tensors
+        ? std::max<int64_t>(num, cfg.cap_max) : num;
+    const int64_t K = (int64_t)(cfg.sh_degree + 1) * (cfg.sh_degree + 1) - 1;
+    const int64_t K_src = src.dim_sh() - 1;
+    const int64_t K_copy = std::min(K, K_src);
+
+    SeedSplats s;
+    s.num = num;
+    s.means.assign((size_t)cap * 3, 0.f);
+    s.quats.assign((size_t)cap * 4, 0.f);
+    s.scales.assign((size_t)cap * 3, 0.f);
+    s.opacities.assign((size_t)cap, 0.f);
+    s.features_dc.assign((size_t)cap * 3, 0.f);
+    s.features_sh.assign((size_t)cap * K * 3, 0.f);
+
+    const float rescale = cfg.relative_scale.value_or(1.0f);
+    const float log_rescale = std::log(std::max(rescale, 1e-12f));
+    Mat3f to_splat = invert3x3(gamut_to_rec709(color.splat_gamut));
+
+    for (int64_t i = 0; i < num; i++) {
+        const int64_t j = pick[(size_t)i];
+        for (int d = 0; d < 3; d++) {
+            s.means[i*3 + d]  = src.means[j*3 + d] * rescale;
+            s.scales[i*3 + d] = src.scales[j*3 + d] + log_rescale;
+        }
+        float qn = 0.f;
+        for (int d = 0; d < 4; d++) qn += src.quats[j*4 + d] * src.quats[j*4 + d];
+        qn = std::sqrt(qn);
+        for (int d = 0; d < 4; d++)
+            s.quats[i*4 + d] = src.quats[j*4 + d] / std::max(qn, 1e-12f);
+        s.opacities[i] = src.opacities[j];
+
+        if (color.convert_seed) {
+            float col[3];
+            for (int d = 0; d < 3; d++)
+                col[d] = src.features_dc[j*3 + d] * kSHC0 + 0.5f;
+            for (int d = 0; d < 3; d++) col[d] = colorspace::srgb_to_linear(col[d]);
+            colorspace::apply3x3(to_splat, col);
+            if (!color.splat_linear)
+                for (int d = 0; d < 3; d++) col[d] = colorspace::linear_to_srgb(col[d]);
+            for (int d = 0; d < 3; d++)
+                s.features_dc[i*3 + d] = (col[d] - 0.5f) / kSHC0;
+        } else {
+            for (int d = 0; d < 3; d++)
+                s.features_dc[i*3 + d] = src.features_dc[j*3 + d];
+        }
+
+        // A gamut change is linear and the DC carries it; the view-dependent
+        // terms ride an encoded curve, so they come across as they are and the
+        // first refinements re-fit them.
+        for (int64_t k = 0; k < K_copy; k++)
+            for (int d = 0; d < 3; d++)
+                s.features_sh[(i*K + k)*3 + d] =
+                    src.features_sh[(j*K_src + k)*3 + d];
+    }
+    return s;
+}
+
+void append_point_seeds(SeedSplats& s, const ColmapPoints3D& pts,
+                        const TrainConfig& cfg, const ColorResolution& color) {
+    const int64_t room = (int64_t)cfg.cap_max - s.num;
+    if (room <= 0 || pts.num() == 0) return;
+
+    // seed_splats() budgets against cap_max, so the room left over IS the cap
+    // for this half; compact, because it is copied into `s` row by row.
+    TrainConfig sub = cfg;
+    sub.cap_max = (int)room;
+    sub.preallocate_splat_tensors = false;
+    SeedSplats p = seed_splats(pts, sub, color);
+
+    const int64_t K = (int64_t)(cfg.sh_degree + 1) * (cfg.sh_degree + 1) - 1;
+    const int64_t at = s.num, total = s.num + p.num;
+    if ((int64_t)s.opacities.size() < total) {
+        s.means.resize((size_t)total * 3, 0.f);
+        s.quats.resize((size_t)total * 4, 0.f);
+        s.scales.resize((size_t)total * 3, 0.f);
+        s.opacities.resize((size_t)total, 0.f);
+        s.features_dc.resize((size_t)total * 3, 0.f);
+        s.features_sh.resize((size_t)total * K * 3, 0.f);
+    }
+    for (int64_t i = 0; i < p.num; i++) {
+        for (int d = 0; d < 3; d++) {
+            s.means[(at + i)*3 + d]        = p.means[i*3 + d];
+            s.scales[(at + i)*3 + d]       = p.scales[i*3 + d];
+            s.features_dc[(at + i)*3 + d]  = p.features_dc[i*3 + d];
+        }
+        for (int d = 0; d < 4; d++)
+            s.quats[(at + i)*4 + d] = p.quats[i*4 + d];
+        s.opacities[at + i] = p.opacities[i];
+        for (int64_t k = 0; k < K; k++)
+            for (int d = 0; d < 3; d++)
+                s.features_sh[((at + i)*K + k)*3 + d] = p.features_sh[(i*K + k)*3 + d];
+    }
+    s.num = total;
 }
 
 
@@ -531,6 +652,10 @@ std::string format_duration(double seconds) {
 void TrainerSession::check_config() {
     if (std::string what = train_config_unsupported(cfg); !what.empty())
         throw std::runtime_error(what);
+    if (!cfg.init_ply.empty() && !cfg.resume.empty())
+        log(lmsg::warn_init_ply_ignored.get());
+    else if (!cfg.init_ply.empty())
+        find_splat_ply(cfg.init_ply);  // before the dataset is parsed, not after
     if (cfg.validation_fraction > 0)
         log(lmsg::warn_validation_unported.get());
     if (cfg.orientation_method != "up" || cfg.center_method != "poses")
@@ -723,7 +848,7 @@ void TrainerSession::setup_engine() {
     engine_reset();
 
     ColorResolution color = resolve_color(cfg);
-    SeedSplats seed = seed_splats(ds.points, cfg, color);
+    SeedSplats seed = seed_world(color);
     int64_t cap = (int64_t)seed.opacities.size();
     int64_t dim_sh = (int64_t)(cfg.sh_degree + 1) * (cfg.sh_degree + 1);
     auto tv = [](std::vector<float>& v, std::vector<int64_t> shape) -> TorchTensorView {
@@ -869,6 +994,22 @@ void TrainerSession::setup_engine() {
     // appearance channel the checkpoint carries must already exist as a
     // restore target, which is what everything above establishes.
     if (!cfg.resume.empty()) restore_checkpoint();
+}
+
+// Where the run's first splats come from: the dataset's point cloud, an
+// --init-ply warm start, or both. A resume overwrites them either way.
+SeedSplats TrainerSession::seed_world(const ColorResolution& color) {
+    if (cfg.init_ply.empty() || !cfg.resume.empty())
+        return seed_splats(ds.points, cfg, color);
+
+    // A run or checkpoint directory resolves to its splat.ply, as --resume does.
+    const std::string ply = find_splat_ply(cfg.init_ply).first;
+    SeedSplats s = seed_splats_from_ply(ply, cfg, color);
+    const int64_t from_ply = s.num;
+    if (cfg.init_ply_add_points) append_point_seeds(s, ds.points, cfg, color);
+    log(lfmt(lmsg::seeded_from_ply,
+             {ply, (long long)from_ply, (long long)(s.num - from_ply)}));
+    return s;
 }
 
 // Restore engine state from cfg.resume, adapting the checkpoint's buffers on

--- a/src/app/TrainerCore.h
+++ b/src/app/TrainerCore.h
@@ -83,6 +83,18 @@ struct SeedSplats {
 SeedSplats seed_splats(const ColmapPoints3D& pts, const TrainConfig& cfg,
                        const ColorResolution& color);
 
+// A warm start from a trained 3DGS PLY (--init-ply): the file supplies every
+// parameter, and only the layout is re-fitted to this run (cap_max, sh_degree,
+// relative_scale, splat gamut). The PLY must be in this run's training frame.
+SeedSplats seed_splats_from_ply(const std::string& path, const TrainConfig& cfg,
+                                const ColorResolution& color);
+
+// The dataset's own seeds appended after the PLY's (--init-ply-add-points), so
+// the warm start covers what the source model has and the point cloud covers
+// what it does not. Adds nothing once `s` already fills cap_max.
+void append_point_seeds(SeedSplats& s, const ColmapPoints3D& pts,
+                        const TrainConfig& cfg, const ColorResolution& color);
+
 
 // ===========================================================================
 // Per-step EngineStepConfig
@@ -227,6 +239,10 @@ public:
     // colour-corrected render). LPIPS is not computed here -- pass
     // --save-eval-images and run reference/python/eval_lpips.py over the PNGs.
     void eval();
+
+    // The seeds setup_engine() hands the engine, from the point cloud and/or
+    // cfg.init_ply.
+    SeedSplats seed_world(const ColorResolution& color);
 
     // Restore engine state from cfg.resume; sets start_step. Called by
     // setup_engine().

--- a/src/config/TrainConfig.h
+++ b/src/config/TrainConfig.h
@@ -147,6 +147,8 @@ inline int train_tier_rank(const char* tier) {
     X(int, background_sh_degree, 4, "splats", "basic", "")                   \
     X(int, background_noise_warmup, 2000, "splats", "expert", "")            \
     X(float, background_noise_pre_warmup, 0.25f, "splats", "expert", "")     \
+    X(std::string, init_ply, "", "splats", "advanced", "none")               \
+    X(bool, init_ply_add_points, false, "splats", "advanced", "")            \
     X(std::optional<float>, scale_init, std::nullopt, "splats", "advanced", "") \
     X(std::optional<float>, opacity_init, std::nullopt, "splats", "advanced", "") \
     X(bool, suppress_initial_scales, false, "splats", "expert", "")          \

--- a/src/i18n/catalog/Log.h
+++ b/src/i18n/catalog/Log.h
@@ -875,6 +875,23 @@ SS_MSG(parsed_dataset,
     TR("Kamera: {0} (bölmeden sonra {1}), başlangıç noktası: {2} "
        "(train_frame_scale={3})"));
 
+// {0} the --init-ply file, {1} its splats after the cap, {2} seeds the
+// dataset's point cloud added on top (0 without --init-ply-add-points).
+SS_MSG(seeded_from_ply,
+    EN("Seeded from {0}: {1} splats from the PLY, {2} from the point cloud"),
+    JA("{0} から初期化しました。PLY のスプラット {1}、点群から {2}"),
+    ZH_HANS("已从 {0} 初始化：来自 PLY 的泼溅 {1} 个，来自点云 {2} 个"),
+    ZH_HANT("已從 {0} 初始化：來自 PLY 的潑濺 {1} 個，來自點雲 {2} 個"),
+    KO("{0}에서 초기화했습니다. PLY의 스플랫 {1}개, 점 구름에서 {2}개"),
+    DE("Initialisiert aus {0}: {1} Splats aus dem PLY, {2} aus der Punktwolke"),
+    FR("Initialisé depuis {0} : {1} splats du PLY, {2} du nuage de points"),
+    ES("Inicializado desde {0}: {1} splats del PLY, {2} de la nube de puntos"),
+    PT("Inicializado a partir de {0}: {1} splats do PLY, {2} da nuvem de pontos"),
+    IT("Inizializzato da {0}: {1} splat dal PLY, {2} dalla nuvola di punti"),
+    NL("Geïnitialiseerd vanuit {0}: {1} splats uit het PLY, {2} uit de puntenwolk"),
+    RU("Инициализировано из {0}: сплатов из PLY {1}, из облака точек {2}"),
+    TR("{0} dosyasından başlatıldı: PLY'den {1} splat, nokta bulutundan {2}"));
+
 // Printed only when --input-depth-is-ray-depth was left unset and there are
 // depth maps to read; {0} is the convention the lens picked.
 SS_MSG(ray_depth_resolved,
@@ -1355,6 +1372,31 @@ SS_MSG(bad_quantization_level,
     NL("quantization_level moet 0 of 1 zijn"),
     RU("quantization_level должен быть 0 или 1"),
     TR("quantization_level 0 ya da 1 olmalı"));
+SS_MSG(warn_init_ply_ignored,
+    EN("warning: --resume restores the checkpoint's own splats, so --init-ply "
+       "is ignored"),
+    JA("警告: --resume はチェックポイント自身のスプラットを復元するため、"
+       "--init-ply は無視されます"),
+    ZH_HANS("警告：--resume 会恢复检查点自己的泼溅，因此 --init-ply 会被忽略"),
+    ZH_HANT("警告：--resume 會恢復檢查點自己的潑濺，因此 --init-ply 會被忽略"),
+    KO("경고: --resume은 체크포인트 자체의 스플랫을 되살리므로 --init-ply는 "
+       "무시됩니다"),
+    DE("Warnung: --resume stellt die Splats des Checkpoints selbst wieder her, "
+       "--init-ply wird ignoriert"),
+    FR("Avertissement : --resume restaure les splats du point de reprise "
+       "lui-même, donc --init-ply est ignoré"),
+    ES("Aviso: --resume restaura los splats del propio punto de control, así "
+       "que --init-ply se ignora"),
+    PT("Aviso: --resume restaura os splats do próprio ponto de verificação, "
+       "então --init-ply é ignorado"),
+    IT("Avviso: --resume ripristina gli splat del checkpoint stesso, quindi "
+       "--init-ply viene ignorato"),
+    NL("Waarschuwing: --resume herstelt de splats van het controlepunt zelf, "
+       "dus --init-ply wordt genegeerd"),
+    RU("Предупреждение: --resume восстанавливает сплаты самой контрольной "
+       "точки, поэтому --init-ply игнорируется"),
+    TR("Uyarı: --resume denetim noktasının kendi splat'larını geri yükler, bu "
+       "yüzden --init-ply yok sayılır"));
 SS_MSG(warn_validation_unported,
     EN("warning: validation images are held out but early stopping / eval is "
        "not ported yet"),

--- a/src/i18n/catalog/TrainFields.h
+++ b/src/i18n/catalog/TrainFields.h
@@ -2364,6 +2364,145 @@ SS_MSG(background_noise_pre_warmup_help,
     TR("Arka plan gürültüsünün en başta ne kadar güçlü olduğu; 0 ile 1 arası. "
        "Yüksek değerler splat'ların ilk adımlarda silinip gitmesini önler."));
 
+SS_MSG(init_ply,
+    EN("Initial splat PLY"), JA("初期スプラットの PLY"),
+    ZH_HANS("初始泼溅 PLY"), ZH_HANT("初始潑濺 PLY"), KO("초기 스플랫 PLY"),
+    DE("Start-PLY der Splats"), FR("PLY de splats initial"),
+    ES("PLY de splats inicial"), PT("PLY de splats inicial"),
+    IT("PLY di splat iniziale"), NL("Start-PLY met splats"),
+    RU("Начальный PLY сплатов"), TR("Başlangıç splat PLY'si"));
+SS_MSG(init_ply_help,
+    EN("Start from an already-trained 3D Gaussian Splatting PLY instead of the "
+       "dataset's point cloud: positions, sizes, rotations, opacities and colors "
+       "all come from the file. Training still begins at step 0 with a fresh "
+       "optimizer, and the file has to come from the same photos with the same "
+       "scene settings, or it will not line up."),
+    JA("データセットの点群の代わりに、すでに学習済みの 3D ガウシアンスプラッ"
+       "ティングの PLY から始めます。位置、大きさ、回転、不透明度、色はファイル"
+       "から読み込みます。学習はステップ 0 から、最適化器も新しい状態で始まりま"
+       "す。ファイルは同じ写真を同じシーン設定で学習したものである必要があり、"
+       "そうでないと位置が合いません。"),
+    ZH_HANS("从一个已经训练好的 3D 高斯泼溅 PLY 开始，而不是数据集的点云：位置、"
+            "大小、旋转、不透明度和颜色都来自该文件。训练仍然从第 0 步开始，优化"
+            "器也是全新的；文件必须用同样的照片、同样的场景设置训练出来，否则对"
+            "不上。"),
+    ZH_HANT("從一個已經訓練好的 3D 高斯潑濺 PLY 開始，而不是資料集的點雲：位置、"
+            "大小、旋轉、不透明度和顏色都來自該檔案。訓練仍然從第 0 步開始，最佳"
+            "化器也是全新的；檔案必須用同樣的照片、同樣的場景設定訓練出來，否則"
+            "對不上。"),
+    KO("데이터셋의 점 구름 대신, 이미 학습된 3D 가우시안 스플래팅 PLY에서 시작"
+       "합니다. 위치, 크기, 회전, 불투명도, 색은 파일에서 가져옵니다. 학습은 그"
+       "래도 0단계에서 최적화기도 새로 시작하며, 파일은 같은 사진을 같은 장면 설"
+       "정으로 학습한 것이어야 맞습니다."),
+    DE("Startet von einem bereits trainierten 3D-Gaussian-Splatting-PLY statt "
+       "von der Punktwolke des Datensatzes: Positionen, Größen, Drehungen, "
+       "Deckkraft und Farben kommen aus der Datei. Das Training beginnt trotzdem "
+       "bei Schritt 0 mit frischem Optimierer, und die Datei muss aus denselben "
+       "Fotos mit denselben Szeneneinstellungen stammen, sonst passt sie nicht."),
+    FR("Démarre depuis un PLY de 3D Gaussian Splatting déjà entraîné plutôt que "
+       "depuis le nuage de points du jeu de données : positions, tailles, "
+       "rotations, opacités et couleurs viennent du fichier. L'entraînement "
+       "commence quand même à l'étape 0 avec un optimiseur neuf, et le fichier "
+       "doit venir des mêmes photos avec les mêmes réglages de scène, sinon il "
+       "ne s'alignera pas."),
+    ES("Empieza desde un PLY de 3D Gaussian Splatting ya entrenado en vez de la "
+       "nube de puntos del conjunto de datos: posiciones, tamaños, rotaciones, "
+       "opacidades y colores salen del archivo. El entrenamiento sigue empezando "
+       "en el paso 0 con el optimizador en blanco, y el archivo tiene que venir "
+       "de las mismas fotos con los mismos ajustes de escena, o no encajará."),
+    PT("Começa a partir de um PLY de 3D Gaussian Splatting já treinado em vez "
+       "da nuvem de pontos do conjunto de dados: posições, tamanhos, rotações, "
+       "opacidades e cores vêm do arquivo. O treinamento ainda começa no passo 0 "
+       "com o otimizador zerado, e o arquivo tem que vir das mesmas fotos com os "
+       "mesmos ajustes de cena, senão não encaixa."),
+    IT("Parte da un PLY di 3D Gaussian Splatting già addestrato invece che "
+       "dalla nuvola di punti del set di dati: posizioni, dimensioni, rotazioni, "
+       "opacità e colori arrivano dal file. L'addestramento comincia comunque "
+       "dal passo 0 con l'ottimizzatore azzerato, e il file deve venire dalle "
+       "stesse foto con le stesse impostazioni di scena, altrimenti non "
+       "combacia."),
+    NL("Begint vanuit een al getraind 3D Gaussian Splatting-PLY in plaats van "
+       "vanuit de puntenwolk van de dataset: posities, formaten, rotaties, "
+       "dekking en kleuren komen uit het bestand. De training start nog steeds "
+       "bij stap 0 met een schone optimalisator, en het bestand moet van "
+       "dezelfde foto's met dezelfde scène-instellingen komen, anders sluit het "
+       "niet aan."),
+    RU("Начинает с уже обученного PLY 3D Gaussian Splatting, а не с облака "
+       "точек набора данных: положения, размеры, повороты, непрозрачность и "
+       "цвета берутся из файла. Обучение всё равно начинается с шага 0 и с "
+       "чистого оптимизатора, а файл должен быть получен из тех же фотографий "
+       "с теми же настройками сцены, иначе он не совпадёт."),
+    TR("Veri kümesinin nokta bulutu yerine, önceden eğitilmiş bir 3D Gaussian "
+       "Splatting PLY dosyasından başlar: konumlar, boyutlar, dönüşler, "
+       "opaklıklar ve renkler dosyadan gelir. Eğitim yine 0. adımdan ve "
+       "sıfırdan bir eniyileyiciyle başlar; dosyanın aynı fotoğraflardan aynı "
+       "sahne ayarlarıyla eğitilmiş olması gerekir, yoksa oturmaz."));
+
+SS_MSG(init_ply_add_points,
+    EN("Add the dataset's points"), JA("データセットの点も足す"),
+    ZH_HANS("同时加上数据集的点"), ZH_HANT("同時加上資料集的點"),
+    KO("데이터셋의 점도 더하기"),
+    DE("Punkte des Datensatzes ergänzen"),
+    FR("Ajouter les points du jeu de données"),
+    ES("Añadir los puntos del conjunto de datos"),
+    PT("Somar os pontos do conjunto de dados"),
+    IT("Aggiungere i punti del set di dati"),
+    NL("Punten van de dataset erbij"),
+    RU("Добавить точки набора данных"),
+    TR("Veri kümesinin noktalarını da ekle"));
+SS_MSG(init_ply_add_points_help,
+    EN("Seed from the dataset's point cloud as well, on top of the PLY rather "
+       "than instead of it: the PLY goes in first and the points fill what is "
+       "left up to the splat cap. For a dataset that has grown since that model "
+       "was trained; without a PLY it does nothing."),
+    JA("PLY を置き換えるのではなく、その上にデータセットの点群からも初期点を置"
+       "きます。先に PLY が入り、残りをスプラット数の上限まで点群が埋めます。そ"
+       "のモデルを学習したあとでデータセットが増えたときに使います。PLY がなけ"
+       "れば何もしません。"),
+    ZH_HANS("不是用 PLY 顶掉数据集的点云，而是两边都用：先放 PLY，再让点云把剩"
+            "下的名额填到泼溅数上限。适合那个模型训练完之后数据集又扩充了的情"
+            "况；没有 PLY 时不起作用。"),
+    ZH_HANT("不是用 PLY 頂掉資料集的點雲，而是兩邊都用：先放 PLY，再讓點雲把剩"
+            "下的名額填到潑濺數上限。適合那個模型訓練完之後資料集又擴充了的情"
+            "況；沒有 PLY 時不起作用。"),
+    KO("PLY로 데이터셋의 점 구름을 대체하지 않고 둘 다 씁니다. PLY가 먼저 들어"
+       "가고 남은 자리를 스플랫 상한까지 점 구름이 채웁니다. 그 모델을 학습한 "
+       "뒤 데이터셋이 늘어났을 때 쓰며, PLY가 없으면 아무 일도 하지 않습니다."),
+    DE("Nimmt zusätzlich die Punktwolke des Datensatzes als Startpunkte, statt "
+       "sie durch das PLY zu ersetzen: das PLY kommt zuerst, die Punkte füllen "
+       "auf, was bis zur Splat-Obergrenze übrig ist. Für einen Datensatz, der "
+       "seit dem Training jenes Modells gewachsen ist; ohne PLY ohne Wirkung."),
+    FR("Amorce aussi depuis le nuage de points du jeu de données, en plus du "
+       "PLY plutôt qu'à sa place : le PLY passe en premier et les points "
+       "remplissent ce qui reste jusqu'à la limite de splats. Pour un jeu de "
+       "données qui s'est étoffé depuis l'entraînement de ce modèle ; sans PLY, "
+       "sans effet."),
+    ES("Siembra también desde la nube de puntos del conjunto de datos, sumandola "
+       "al PLY en vez de sustituirla: el PLY entra primero y los puntos rellenan "
+       "lo que quede hasta el límite de splats. Para un conjunto de datos que ha "
+       "crecido desde que se entrenó ese modelo; sin PLY no hace nada."),
+    PT("Semeia também a partir da nuvem de pontos do conjunto de dados, somando "
+       "ao PLY em vez de substituí-la: o PLY entra primeiro e os pontos "
+       "preenchem o que sobrar até o limite de splats. Para um conjunto de dados "
+       "que cresceu depois que aquele modelo foi treinado; sem PLY não faz "
+       "nada."),
+    IT("Semina anche dalla nuvola di punti del set di dati, sommandola al PLY "
+       "invece di sostituirla: il PLY entra per primo e i punti riempiono quel "
+       "che resta fino al limite di splat. Per un set di dati cresciuto da "
+       "quando quel modello è stato addestrato; senza PLY non fa nulla."),
+    NL("Zaait ook vanuit de puntenwolk van de dataset, bovenop het PLY in plaats "
+       "van in de plaats daarvan: het PLY gaat er eerst in en de punten vullen "
+       "aan tot de bovengrens. Voor een dataset die gegroeid is sinds dat model "
+       "getraind werd; zonder PLY doet dit niets."),
+    RU("Берёт начальные точки ещё и из облака точек набора данных, добавляя их к "
+       "PLY, а не заменяя им: сначала идёт PLY, а точки заполняют то, что "
+       "осталось до предела числа сплатов. Для набора данных, выросшего с тех "
+       "пор, как ту модель обучали; без PLY ничего не делает."),
+    TR("Veri kümesinin nokta bulutunu PLY'nin yerine koymak yerine onun üstüne "
+       "ekler: önce PLY girer, kalan yeri splat sınırına kadar noktalar "
+       "doldurur. O model eğitildikten sonra büyümüş bir veri kümesi için; PLY "
+       "yoksa hiçbir şey yapmaz."));
+
 SS_MSG(scale_init,
     EN("Initial splat size"), JA("スプラットの初期サイズ"),
     ZH_HANS("泼溅初始大小"), ZH_HANT("潑濺初始大小"), KO("스플랫 초기 크기"),


### PR DESCRIPTION
--init-ply <file.ply|run_dir|step-*.ckpt> seeds the run from an already-trained 3DGS PLY instead of the dataset's point cloud: means, scales, rotations, opacities and SH all come from the file, and only the layout is re-fitted to the run -- splats past cap_max dropped by lowest opacity, SH truncated or zero-padded to sh_degree, relative_scale applied to the means and log-scales, DC converted to the splat gamut when convert_initial_point_cloud_color is on.

It is not a resume: the step counter starts at 0 and the optimizer starts empty. The PLY has to be in the run's training frame, so in practice it has to come from the same dataset with the same scene settings -- nothing registers it. --resume wins when both are given, with a warning, since a resumed run's config.json carries the original --init-ply.

--init-ply-add-points seeds from the dataset's point cloud as well instead of replacing it, filling what is left up to cap_max, for a dataset that has grown since the source model was trained.