### PR TITLE
Fix null shape read in the multi-scale loss pyramid when masks are loaded

### DIFF
--- a/src/backend/vulkan/kernels/PerPixelLoss.cpp
+++ b/src/backend/vulkan/kernels/PerPixelLoss.cpp
@@ -733,13 +733,14 @@ LossValues compute_multi_scale_per_pixel_losses(
         // fully-masked tile go unrendered (docs/datasets.md, "Skipping tiles").
         auto ds_m = [&](TorchTensorView& prev, TorchTensorView& curr,
                         const std::string& name, int C) {
+            // Absent modalities have an empty shape from scale 2 on.
+            if (!_has(prev)) return;
             const TorchTensorView& mk = ref_alpha_s[sc - 1];
             const auto& pps = std::get<2>(prev);
             const auto& mks = std::get<2>(mk);
             // A mask at its own resolution cannot index this image's children.
             const bool same = _has(mk) && mks[0] == pps[0] &&
                               mks[1] == pps[1] && mks[2] == pps[2];
-            if (!_has(prev)) return;
             if (!has_mask || !same) {
                 ds_f(prev, curr, name, C);
                 return;

--- a/src/kernels/loss/PerPixelLoss.cu
+++ b/src/kernels/loss/PerPixelLoss.cu
@@ -1065,13 +1065,14 @@ LossValues compute_multi_scale_per_pixel_losses(
         // fully-masked tile go unrendered (docs/datasets.md, "Skipping tiles").
         auto ds_m = [&](TorchTensorView& prev, TorchTensorView& curr,
                         const std::string& name, int C) {
+            // Absent modalities have an empty shape from scale 2 on.
+            if (!_has(prev)) return;
             const TorchTensorView& mk = ref_alpha_s[sc-1];
             const auto& pps = std::get<2>(prev);
             const auto& mks = std::get<2>(mk);
             // A mask at its own resolution cannot index this image's children.
             const bool same = _has(mk) && mks[0] == pps[0] &&
                               mks[1] == pps[1] && mks[2] == pps[2];
-            if (!_has(prev)) return;
             if (!has_mask || !same) {
                 ds_f(prev, curr, name, C);
                 return;


### PR DESCRIPTION
Refs #29.

**This is a draft, and I have not built or run it yet.** Both of our machines are busy on long training runs, so I cannot compile it today. I am opening it now because the change is small and you may want it sooner than I can get to verifying it. I will build it, verify on a real masked 4096px run, and mark it ready for review once that is done.

## What this changes

`ds_m` in the multi-scale loss pyramid reads `std::get<2>(prev)[0]` before its `_has(prev)` guard. Modalities that are absent stay default constructed from scale 2 on, and a default constructed `TorchTensorView` has an empty shape vector, so that read dereferences a null pointer. This moves the guard above the shape reads.

Behaviour should be unchanged. When `prev` is absent the lambda already did nothing, because both the `ds_f` path and the masked path are no-ops for a missing input.

The full root cause, the crash trace and the isolation table are in #29, so I have not repeated them here.

## Scope

The same ordering is in `src/kernels/loss/PerPixelLoss.cu`, so it is patched identically. I have no CUDA hardware, so I cannot verify that half at all. Only the Vulkan file corresponds to the crash I actually saw.

## Test coverage

The combination that reproduces this is not covered today: minimal modalities, plus a mask, plus 3 scales. `mask_loss_semantics.cpp` runs at 1 scale, and the 3 scale case in `msloss_parity.cpp` (`full`) has every modality present, while its `minimal = true` cases run at 1 or 2 scales.

Raising `edge_aware` from 2 scales to 3 looks like it would cover it. I have not done that here, because it needs the reference dump regenerated and that seemed like your call rather than mine. Glad to add it if you would like.

Thanks for the project.
