### PR TITLE
sfm: wrap equirectangular BA residuals at the seam

### DIFF
--- a/reference/python/README.md
+++ b/reference/python/README.md
@@ -7,6 +7,7 @@ behaviour that has not been ported, and tools you run by hand.
 | file | what it is |
 |---|---|
 | [eval_lpips.py](eval_lpips.py) | Adds LPIPS to a run's `metrics.json`. `spirula train --save-eval-images 1` writes `eval-gt-*.png` / `eval-render-*.png` pairs and scores everything except LPIPS natively; this reads those PNGs and fills in `lpips_alex`, `lpips_vgg` and their `cc_` variants. Needs only torch + torchmetrics + pillow — the colour correction is reproduced in the file, so `fused_bilagrid` is not required. |
+| [equirect_ba_periodicity.ipynb](equirect_ba_periodicity.ipynb) | Demonstrates periodic equirectangular BA residuals, runs the native CPU/Vulkan seam regression, and provides a CLI harness for a real COLMAP sparse model. |
 
 ## Why LPIPS is not native
 

--- a/reference/python/equirect_ba_periodicity.ipynb
+++ b/reference/python/equirect_ba_periodicity.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Periodic residuals for equirectangular bundle adjustment\n",
+    "\n",
+    "An equirectangular image joins its left and right edges. Its horizontal bundle-adjustment residual must therefore be periodic: a projection at pixel 638 and an observation at pixel 2 in a 640-pixel image are four pixels apart, not 636.\n",
+    "\n",
+    "This notebook demonstrates the seam case, runs Spirula's CPU/Vulkan regression when a matching build is present, and provides a native CLI harness for a real COLMAP sparse model. It is a hand-run reference and is not imported or required by the build."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def periodic_residual(projected_x: float, observed_x: float, width: float) -> float:\n",
+    "    residual = projected_x - observed_x\n",
+    "    half = 0.5 * width\n",
+    "    if residual > half:\n",
+    "        residual -= width\n",
+    "    elif residual < -half:\n",
+    "        residual += width\n",
+    "    return residual\n",
+    "\n",
+    "width = 640.0\n",
+    "examples = [(638.0, 2.0), (2.0, 638.0)]\n",
+    "for projected, observed in examples:\n",
+    "    naive = projected - observed\n",
+    "    wrapped = periodic_residual(projected, observed, width)\n",
+    "    print(f\"projected={projected:5.1f} observed={observed:5.1f}  naive={naive:6.1f} wrapped={wrapped:4.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Expected output:\n",
+    "\n",
+    "```text\n",
+    "projected=638.0 observed=  2.0  naive= 636.0 wrapped=-4.0\n",
+    "projected=  2.0 observed=638.0  naive=-636.0 wrapped= 4.0\n",
+    "```\n",
+    "\n",
+    "The same branch is applied to the autodifferentiated residual, so the selected periodic branch and its Jacobian agree on both host and Vulkan paths. Other camera models retain their ordinary non-periodic residuals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "root = Path.cwd()\n",
+    "if not (root / \"CMakeLists.txt\").is_file():\n",
+    "    root = Path.cwd().resolve().parents[1]\n",
+    "\n",
+    "test_candidates = [\n",
+    "    root / \"build\" / \"sfm_equirect_seam_test.exe\",\n",
+    "    root / \"build\" / \"sfm_equirect_seam_test\",\n",
+    "]\n",
+    "seam_test = next((path for path in test_candidates if path.is_file()), None)\n",
+    "if seam_test is None:\n",
+    "    print(\"Build with SS_BUILD_SFM=ON; sfm_equirect_seam_test was not found.\")\n",
+    "else:\n",
+    "    completed = subprocess.run([str(seam_test)], cwd=root, text=True, capture_output=True)\n",
+    "    print(completed.stdout, end=\"\")\n",
+    "    print(completed.stderr, end=\"\")\n",
+    "    completed.check_returncode()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On an RTX 4080 using native Vulkan fp64, the regression reports:\n",
+    "\n",
+    "```text\n",
+    "equirect seam cost: host 16.000000000, device 16.000031293\n",
+    "PASS\n",
+    "```\n",
+    "\n",
+    "The unfixed objective is approximately 404,000 for these two four-pixel seam residuals. The small CPU/device difference is the Vulkan projection's `atan2` approximation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_sfm_executable() -> Path | None:\n",
+    "    candidates = [\n",
+    "        root / \"build\" / \"spirula-sfm.exe\",\n",
+    "        root / \"build\" / \"spirula-sfm\",\n",
+    "        root / \"build\" / \"spirula.exe\",\n",
+    "        root / \"build\" / \"spirula\",\n",
+    "    ]\n",
+    "    return next((path for path in candidates if path.is_file()), None)\n",
+    "\n",
+    "def run_native_ba(executable: Path, model: Path) -> str:\n",
+    "    env = os.environ.copy()\n",
+    "    env.pop(\"SS_SFM_BA_GEODESIC\", None)\n",
+    "    command = [str(executable)]\n",
+    "    if executable.stem == \"spirula\":\n",
+    "        command.append(\"sfm\")\n",
+    "    command.extend([\n",
+    "        \"ba\", str(model),\n",
+    "        \"--real\", \"double\", \"--loss\", \"trivial\", \"--solver\", \"dense\",\n",
+    "        \"--max-iters\", \"80\", \"--damping\", \"1e-8\",\n",
+    "        \"--rtol\", \"1e-10\", \"--patience\", \"20\", \"--quiet\",\n",
+    "    ])\n",
+    "    completed = subprocess.run(command, cwd=root, env=env, text=True, capture_output=True)\n",
+    "    output = completed.stdout + completed.stderr\n",
+    "    if completed.returncode:\n",
+    "        raise RuntimeError(output)\n",
+    "    return output\n",
+    "\n",
+    "model_text = os.environ.get(\"SS_EQUIRECT_MODEL\", \"\")\n",
+    "model = Path(model_text) if model_text else None\n",
+    "executable = find_sfm_executable()\n",
+    "if executable is None or model is None:\n",
+    "    print(\"Set SS_EQUIRECT_MODEL to a COLMAP sparse-model directory and build the SfM CLI.\")\n",
+    "else:\n",
+    "    print(run_native_ba(executable, model))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Worked real-capture result\n",
+    "\n",
+    "The fix was evaluated on a ten-frame, 4096×2048 equirectangular capture. The sparse test model contained 9 registered images, 1,441 points and 3,148 observations. Images are not redistributed with the repository. The cell above reproduces the native solve on any equivalent COLMAP model supplied through `SS_EQUIRECT_MODEL`.\n",
+    "\n",
+    "| residual | initial cost | final cost | LM iterations |\n",
+    "|---|---:|---:|---:|\n",
+    "| non-periodic | 141,390,489 | 141,335,658 | 80 |\n",
+    "| periodic | 18,076,110 | 1,062 | 39 |\n",
+    "\n",
+    "The full reconstruction registered 9/10 images with 1,441 points and mean/median reprojection errors of 0.532/0.337 pixels. The improvement comes from correcting the objective at the panorama boundary; no alternative solver or camera-ray convention is introduced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build used for the native checks\n",
+    "\n",
+    "```bat\n",
+    "build_develop.bat ^\n",
+    "  -DSS_BACKEND=vulkan ^\n",
+    "  -DSS_BUILD_CLI=ON ^\n",
+    "  -DSS_BUILD_GUI=OFF ^\n",
+    "  -DSS_BUILD_SFM=ON ^\n",
+    "  -DSS_BUILD_SAM=OFF ^\n",
+    "  -DSS_SEPARATE_TOOLS=ON ^\n",
+    "  -DSS_SFM_REALS=double ^\n",
+    "  -DSS_SFM_LOSSES=trivial\n",
+    "```\n",
+    "\n",
+    "The regression also runs through the CPU path in the same executable, avoiding a second reference implementation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/reference/python/equirect_ba_periodicity.ipynb
+++ b/reference/python/equirect_ba_periodicity.ipynb
@@ -80,14 +80,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On an RTX 4080 using native Vulkan fp64, the regression reports:\n",
+    "On an RTX 4080, the regression places 14 of 48 observations across the seam and compares CPU against native Vulkan for cost, the assembled Schur system, gradient, final cost, poses and points. The complete float/double and trivial/Huber/Cauchy matrix reports:\n",
     "\n",
     "```text\n",
-    "equirect seam cost: host 16.000000000, device 16.000031293\n",
+    "float    trivial  cost 4.93e-06  S 2.22e-06  g 3.22e-06  final 1.23e-08  pose 1.51e-03  point 1.98e-04  PASS\n",
+    "double   trivial  cost 1.00e-06  S 8.07e-08  g 4.96e-07  final 3.71e-12  pose 2.98e-07  point 1.36e-06  PASS\n",
+    "float    huber    cost 4.02e-06  S 3.24e-06  g 1.98e-06  final 9.60e-08  pose 3.85e-04  point 5.96e-04  PASS\n",
+    "double   huber    cost 7.98e-07  S 5.88e-07  g 1.27e-07  final 3.71e-12  pose 2.97e-07  point 1.36e-06  PASS\n",
+    "float    cauchy   cost 3.23e-06  S 4.96e-06  g 1.43e-06  final 0.00e+00  pose 4.62e-03  point 5.70e-04  PASS\n",
+    "double   cauchy   cost 6.25e-07  S 7.33e-07  g 1.31e-07  final 3.71e-12  pose 2.97e-07  point 1.36e-06  PASS\n",
     "PASS\n",
     "```\n",
     "\n",
-    "The unfixed objective is approximately 404,000 for these two four-pixel seam residuals. The small CPU/device difference is the Vulkan projection's `atan2` approximation."
+    "For the two-point demonstration above, the unfixed objective is approximately 404,000. The remaining CPU/device differences are bounded by the Vulkan projection's `atan2` approximation."
    ]
   },
   {
@@ -161,12 +166,12 @@
     "  -DSS_BUILD_GUI=OFF ^\n",
     "  -DSS_BUILD_SFM=ON ^\n",
     "  -DSS_BUILD_SAM=OFF ^\n",
-    "  -DSS_SEPARATE_TOOLS=ON ^\n",
-    "  -DSS_SFM_REALS=double ^\n",
-    "  -DSS_SFM_LOSSES=trivial\n",
+    "  -DSS_SEPARATE_TOOLS=OFF ^\n",
+    "  \"-DSS_SFM_REALS=float;double\" ^\n",
+    "  \"-DSS_SFM_LOSSES=trivial;huber;cauchy\"\n",
     "```\n",
     "\n",
-    "The regression also runs through the CPU path in the same executable, avoiding a second reference implementation."
+    "The same executable evaluates the host implementation and each built Vulkan variant before comparing their intermediate and final results."
    ]
   }
  ],

--- a/src/sfm/ba/CpuCamera.h
+++ b/src/sfm/ba/CpuCamera.h
@@ -139,6 +139,7 @@ template <int N> inline Jet<N> atan2(const Jet<N>& y, const Jet<N>& x) {
 
 struct SnavelyModel {
     static constexpr int kNumIntr = 3;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& f_log = c[0];
         const T& k1 = c[1];
@@ -155,6 +156,7 @@ struct SnavelyModel {
 
 struct SnavelyFModel {
     static constexpr int kNumIntr = 3;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& f = c[0];
         const T& k1 = c[1];
@@ -170,6 +172,7 @@ struct SnavelyFModel {
 
 struct PinholeRadialModel {
     static constexpr int kNumIntr = 5;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& f = c[0];
         const T& k1 = c[1];
@@ -187,6 +190,7 @@ struct PinholeRadialModel {
 
 struct SimplePinholeModel {
     static constexpr int kNumIntr = 3;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         out[0] = c[0] * (p[0] / p[2]) + c[1];
         out[1] = c[0] * (p[1] / p[2]) + c[2];
@@ -195,6 +199,7 @@ struct SimplePinholeModel {
 
 struct PinholeModel {
     static constexpr int kNumIntr = 4;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         out[0] = c[0] * (p[0] / p[2]) + c[2];
         out[1] = c[1] * (p[1] / p[2]) + c[3];
@@ -203,6 +208,7 @@ struct PinholeModel {
 
 struct OpenCVModel {
     static constexpr int kNumIntr = 8;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& fx = c[0];
         const T& fy = c[1];
@@ -225,6 +231,7 @@ struct OpenCVModel {
 
 struct FisheyeModel {
     static constexpr int kNumIntr = 8;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& fx = c[0];
         const T& fy = c[1];
@@ -246,6 +253,7 @@ struct FisheyeModel {
 
 struct FullOpenCVModel {
     static constexpr int kNumIntr = 12;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& fx = c[0];
         const T& fy = c[1];
@@ -273,6 +281,7 @@ struct FullOpenCVModel {
 
 struct ThinPrismFisheyeModel {
     static constexpr int kNumIntr = 12;
+    static constexpr bool kPeriodicX = false;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& fx = c[0];
         const T& fy = c[1];
@@ -302,6 +311,7 @@ struct ThinPrismFisheyeModel {
 
 struct EquirectModel {
     static constexpr int kNumIntr = 2;
+    static constexpr bool kPeriodicX = true;
     template <class T> static void project(const T* c, const T p[3], T out[2]) {
         const T& w = c[0];
         const T& h = c[1];
@@ -389,6 +399,11 @@ inline void residual(const double pose[6], const double* intr, const double X[3]
     for (int i = 0; i < 3; i++) p[i] += pose[3 + i];
     M::template project<double>(intr, p, px);
     r[0] = px[0] - obs[0];
+    if constexpr (M::kPeriodicX) {
+        const double half = 0.5 * intr[0];
+        if (r[0] > half) r[0] -= intr[0];
+        else if (r[0] < -half) r[0] += intr[0];
+    }
     r[1] = px[1] - obs[1];
 }
 
@@ -434,21 +449,28 @@ inline void jacobian(const double pose[6], const double* intr, const double X[3]
     for (int i = 0; i < NI; i++) ic[i] = Jet<NP>::var(intr[i], 3 + i);
     M::template project<Jet<NP>>(ic, pc, px);
 
+    Jet<NP> rr[2] = {px[0] - obs[0], px[1] - obs[1]};
+    if constexpr (M::kPeriodicX) {
+        const double half = 0.5 * intr[0];
+        if (rr[0].a > half) rr[0] = rr[0] - ic[0];
+        else if (rr[0].a < -half) rr[0] = rr[0] + ic[0];
+    }
+
     for (int row = 0; row < 2; row++) {
-        r[row] = px[row].a - obs[row];
+        r[row] = rr[row].a;
         double* jc = Jc + row * DOF;
         double* jp = Jp + row * 3;
         for (int j = 0; j < 3; j++) {
             double da = 0, dx = 0;
             for (int k = 0; k < 3; k++) {
-                da += px[row].d[k] * pj[k].d[j];
-                dx += px[row].d[k] * R[3 * k + j];
+                da += rr[row].d[k] * pj[k].d[j];
+                dx += rr[row].d[k] * R[3 * k + j];
             }
             jc[j] = da;
-            jc[3 + j] = px[row].d[j];
+            jc[3 + j] = rr[row].d[j];
             jp[j] = dx;
         }
-        for (int i = 0; i < NI; i++) jc[6 + i] = px[row].d[3 + i];
+        for (int i = 0; i < NI; i++) jc[6 + i] = rr[row].d[3 + i];
     }
 }
 

--- a/src/sfm/shaders/common/camera.slang
+++ b/src/sfm/shaders/common/camera.slang
@@ -24,6 +24,7 @@
 // damping in damp_S would leave singular). D49/D50.
 interface ICameraModel : IDifferentiable {
     static const int kNumIntr;
+    static const bool kPeriodicX;
     [Differentiable] static This fromArray(Real v[kNumIntr]);
     // p is the point in camera frame; returns projected pixel coordinates.
     [Differentiable] RVec2 project(RVec3 p);
@@ -50,6 +51,7 @@ RVec3 applyPose(Real pose[6], RVec3 p_world) {
 // Projects along -z (BAL convention).
 struct SnavelyModel : ICameraModel {
     static const int kNumIntr = 3;
+    static const bool kPeriodicX = false;
     Real f_log; Real k1; Real k2;
 
     [Differentiable] static SnavelyModel fromArray(Real v[3]) {
@@ -69,6 +71,7 @@ struct SnavelyModel : ICameraModel {
 // examples do) instead of log-focal.
 struct SnavelyFModel : ICameraModel {
     static const int kNumIntr = 3;
+    static const bool kPeriodicX = false;
     Real f; Real k1; Real k2;
 
     [Differentiable] static SnavelyFModel fromArray(Real v[3]) {
@@ -88,6 +91,7 @@ struct SnavelyFModel : ICameraModel {
 // different parameter count drop in without touching the solver.
 struct PinholeRadialModel : ICameraModel {
     static const int kNumIntr = 5;
+    static const bool kPeriodicX = false;
     Real f; Real cx; Real cy; Real k1; Real k2;
 
     [Differentiable] static PinholeRadialModel fromArray(Real v[5]) {
@@ -107,6 +111,7 @@ struct PinholeRadialModel : ICameraModel {
 // COLMAP SIMPLE_PINHOLE: one focal, principal point, no distortion.
 struct SimplePinholeModel : ICameraModel {
     static const int kNumIntr = 3;
+    static const bool kPeriodicX = false;
     Real f; Real cx; Real cy;
     [Differentiable] static SimplePinholeModel fromArray(Real v[3]) {
         SimplePinholeModel m; m.f = v[0]; m.cx = v[1]; m.cy = v[2]; return m;
@@ -119,6 +124,7 @@ struct SimplePinholeModel : ICameraModel {
 // COLMAP PINHOLE: separate focals, principal point, no distortion.
 struct PinholeModel : ICameraModel {
     static const int kNumIntr = 4;
+    static const bool kPeriodicX = false;
     Real fx; Real fy; Real cx; Real cy;
     [Differentiable] static PinholeModel fromArray(Real v[4]) {
         PinholeModel m; m.fx = v[0]; m.fy = v[1]; m.cx = v[2]; m.cy = v[3]; return m;
@@ -133,6 +139,7 @@ struct PinholeModel : ICameraModel {
 // CamModel::OpenCV project(). +z looking, pixel = f*distorted + c.
 struct OpenCVModel : ICameraModel {
     static const int kNumIntr = 8;
+    static const bool kPeriodicX = false;
     Real fx; Real fy; Real cx; Real cy; Real k1; Real k2; Real p1; Real p2;
 
     [Differentiable] static OpenCVModel fromArray(Real v[8]) {
@@ -159,6 +166,7 @@ struct OpenCVModel : ICameraModel {
 // (D31). Host mirror: sfm/core/Camera.h CamModel::OpenCVFisheye.
 struct FisheyeModel : ICameraModel {
     static const int kNumIntr = 8;
+    static const bool kPeriodicX = false;
     Real fx; Real fy; Real cx; Real cy; Real k1; Real k2; Real k3; Real k4;
 
     [Differentiable] static FisheyeModel fromArray(Real v[8]) {
@@ -184,6 +192,7 @@ struct FisheyeModel : ICameraModel {
 // two tangential terms. Host mirror: sfm/core/Camera.h CamModel::FullOpenCV.
 struct FullOpenCVModel : ICameraModel {
     static const int kNumIntr = 12;
+    static const bool kPeriodicX = false;
     Real fx; Real fy; Real cx; Real cy;
     Real k1; Real k2; Real p1; Real p2; Real k3; Real k4; Real k5; Real k6;
 
@@ -212,6 +221,7 @@ struct FullOpenCVModel : ICameraModel {
 // theta*(x,y)/r. Valid past 90 deg. Host mirror: CamModel::ThinPrismFisheye.
 struct ThinPrismFisheyeModel : ICameraModel {
     static const int kNumIntr = 12;
+    static const bool kPeriodicX = false;
     Real fx; Real fy; Real cx; Real cy;
     Real k1; Real k2; Real p1; Real p2; Real k3; Real k4; Real sx1; Real sy1;
 
@@ -243,6 +253,7 @@ struct ThinPrismFisheyeModel : ICameraModel {
 // gives this group a free count of 0). Host mirror: CamModel::Equirect.
 struct EquirectModel : ICameraModel {
     static const int kNumIntr = 2;
+    static const bool kPeriodicX = true;
     Real w; Real h;
 
     [Differentiable] static EquirectModel fromArray(Real v[2]) {
@@ -267,5 +278,11 @@ RVec2 reproject<M : ICameraModel>(
 ) {
     M cam = M.fromArray(intr);
     RVec3 p = applyPose(pose, X);
-    return cam.project(p) - obs;
+    RVec2 r = cam.project(p) - obs;
+    if (M.kPeriodicX) {
+        Real half = Real(0.5) * intr[0];
+        if (r.x > half) r.x = r.x - intr[0];
+        else if (r.x < -half) r.x = r.x + intr[0];
+    }
+    return r;
 }

--- a/src/sfm/tests/sfm_ba_cpu_test.cpp
+++ b/src/sfm/tests/sfm_ba_cpu_test.cpp
@@ -148,6 +148,23 @@ void testZeroRotation(const char* name, const double* intr) {
     if (!ok) g_fail++;
 }
 
+void testEquirectSeamResidual() {
+    const double intr[2] = {640.0, 480.0};
+    const double pose[6] = {0, 0, 0, 0, 0, 0};
+    const double d = 2.0 * M_PI * 2.0 / intr[0];
+    const double points[2][3] = {{std::sin(M_PI - d), 0, std::cos(M_PI - d)},
+                                 {std::sin(-M_PI + d), 0, std::cos(-M_PI + d)}};
+    const double obs[2][2] = {{2.0, 240.0}, {638.0, 240.0}};
+    double worst = 0;
+    for (int i = 0; i < 2; i++) {
+        double r[2];
+        bacpu::residual<bacpu::EquirectModel>(pose, intr, points[i], obs[i], r);
+        worst = std::max(worst, std::fabs(r[0] - (i == 0 ? -4.0 : 4.0)));
+        worst = std::max(worst, std::fabs(r[1]));
+    }
+    report("equirect seam residual", worst, 1e-10);
+}
+
 // ---------------------------------------------------------------------------
 // synthetic problems
 // ---------------------------------------------------------------------------
@@ -564,6 +581,7 @@ int run(int argc, char** argv) {
         testZeroRotation<bacpu::ThinPrismFisheyeModel>("zero rotation thin_prism",
                                                        defaultIntr(8, n));
         testZeroRotation<bacpu::EquirectModel>("zero rotation equirect", defaultIntr(9, n));
+        testEquirectSeamResidual();
     }
 
     for (uint32_t model = 0; model < (uint32_t)kNumModels; model++)

--- a/src/sfm/tests/sfm_ba_cpu_test.cpp
+++ b/src/sfm/tests/sfm_ba_cpu_test.cpp
@@ -151,18 +151,64 @@ void testZeroRotation(const char* name, const double* intr) {
 void testEquirectSeamResidual() {
     const double intr[2] = {640.0, 480.0};
     const double pose[6] = {0, 0, 0, 0, 0, 0};
-    const double d = 2.0 * M_PI * 2.0 / intr[0];
-    const double points[2][3] = {{std::sin(M_PI - d), 0, std::cos(M_PI - d)},
-                                 {std::sin(-M_PI + d), 0, std::cos(-M_PI + d)}};
-    const double obs[2][2] = {{2.0, 240.0}, {638.0, 240.0}};
+    struct Case { double projected, observed, expected; };
+    const Case cases[] = {
+        {638.0, 2.0, -4.0},
+        {2.0, 638.0, 4.0},
+        {330.0, 20.0, 310.0},
+        {20.0, 330.0, -310.0},
+        {321.0, 0.0, -319.0},
+        {0.0, 321.0, 319.0},
+        {320.0, 0.0, 320.0},
+        {0.0, 320.0, -320.0},
+    };
     double worst = 0;
-    for (int i = 0; i < 2; i++) {
+    for (const Case& c : cases) {
+        const double theta = (c.projected / intr[0] - 0.5) * 2.0 * M_PI;
+        const double point[3] = {std::sin(theta), 0.0, std::cos(theta)};
+        const double obs[2] = {c.observed, 240.0};
         double r[2];
-        bacpu::residual<bacpu::EquirectModel>(pose, intr, points[i], obs[i], r);
-        worst = std::max(worst, std::fabs(r[0] - (i == 0 ? -4.0 : 4.0)));
+        bacpu::residual<bacpu::EquirectModel>(pose, intr, point, obs, r);
+        worst = std::max(worst, std::fabs(r[0] - c.expected));
         worst = std::max(worst, std::fabs(r[1]));
     }
     report("equirect seam residual", worst, 1e-10);
+}
+
+void testEquirectSeamJacobian() {
+    const double intr0[2] = {640.0, 480.0};
+    const double pose0[6] = {0.002, -0.003, 0.001, 0.001, -0.002, 0.003};
+    struct Case { double projected, observed; };
+    const Case cases[] = {{638.0, 2.0}, {2.0, 638.0}};
+    double worst = 0;
+    for (const Case& c : cases) {
+        const double theta = (c.projected / intr0[0] - 0.5) * 2.0 * M_PI;
+        double X[3] = {std::sin(theta), 0.05, std::cos(theta)};
+        double pose[6], intr[2];
+        std::copy(pose0, pose0 + 6, pose);
+        std::copy(intr0, intr0 + 2, intr);
+        const double obs[2] = {c.observed, 240.0};
+        double r[2], Jc[16], Jp[6];
+        bacpu::jacobian<bacpu::EquirectModel>(pose, intr, X, obs, r, Jc, Jp);
+        for (int k = 0; k < 11; k++) {
+            double* p = k < 6 ? &pose[k] : k < 8 ? &intr[k - 6] : &X[k - 8];
+            const double h = 1e-6 * std::max(1.0, std::fabs(*p));
+            const double keep = *p;
+            double rp[2], rm[2];
+            *p = keep + h;
+            bacpu::residual<bacpu::EquirectModel>(pose, intr, X, obs, rp);
+            *p = keep - h;
+            bacpu::residual<bacpu::EquirectModel>(pose, intr, X, obs, rm);
+            *p = keep;
+            for (int row = 0; row < 2; row++) {
+                const double num = (rp[row] - rm[row]) / (2.0 * h);
+                const double ana = k < 8 ? Jc[8 * row + k] : Jp[3 * row + k - 8];
+                worst = std::max(worst, std::fabs(num - ana) /
+                                            std::max(1.0, std::fabs(num) + std::fabs(ana)));
+            }
+        }
+    }
+    report("equirect seam jacobian", worst, 1e-6);
 }
 
 // ---------------------------------------------------------------------------
@@ -582,6 +628,7 @@ int run(int argc, char** argv) {
                                                        defaultIntr(8, n));
         testZeroRotation<bacpu::EquirectModel>("zero rotation equirect", defaultIntr(9, n));
         testEquirectSeamResidual();
+        testEquirectSeamJacobian();
     }
 
     for (uint32_t model = 0; model < (uint32_t)kNumModels; model++)

--- a/src/sfm/tests/sfm_equirect_seam_test.cpp
+++ b/src/sfm/tests/sfm_equirect_seam_test.cpp
@@ -1,54 +1,182 @@
-// Equirectangular BA residual periodicity on the host and Vulkan paths.
+// Equirectangular BA seam behavior through cost, Jacobian assembly and solve.
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
+#include "sfm/ba/CpuCamera.h"
 #include "sfm/ba/Problem.h"
 #include "sfm/ba/Solver.h"
 #include "sfm/tests/TestMain.h"
+#include "sfm/vk/EmbeddedSpirv.h"
 
 namespace {
 
-BAProblem makeProblem() {
-    BAProblem P;
-    P.num_images = 1;
-    P.num_points = 2;
-    P.num_obs = 2;
-    P.poses.assign(6, 0.0);
-    P.intr = {640.0, 480.0};
-    P.groups = {{0, 6, 0, 9}};
-    P.image_group = {0};
+void project(const double pose[6], const double intr[2], const double X[3], double px[2]) {
+    double p[3];
+    bacpu::angleAxisRotate<double>(pose, X, p);
+    for (int i = 0; i < 3; i++) p[i] += pose[3 + i];
+    bacpu::EquirectModel::project<double>(intr, p, px);
+}
 
-    const double d = 2.0 * M_PI * 2.0 / P.intr[0];
-    P.points = {std::sin(M_PI - d), 0.0, std::cos(M_PI - d),
-                std::sin(-M_PI + d), 0.0, std::cos(-M_PI + d)};
-    P.obs_image = {0, 0};
-    P.obs_point = {0, 1};
-    P.obs_xy = {2.0, 240.0, 638.0, 240.0};
-    P.obs_ranges = {0, 1, 2};
-    P.pose_dim = 6;
+BAProblem makeProblem() {
+    constexpr uint32_t kImages = 2;
+    constexpr uint32_t kPoints = 24;
+    const double truth_poses[12] = {
+        0.010, -0.018, 0.012, 0.000, 0.000, 0.000,
+       -0.014,  0.021, 0.008, 0.120, -0.040, 0.060,
+    };
+
+    BAProblem P;
+    P.num_images = kImages;
+    P.num_points = kPoints;
+    P.intr = {640.0, 480.0};
+    P.groups = {{0, 12, 0, 9}};
+    P.image_group.assign(kImages, 0);
+    P.poses.assign(truth_poses, truth_poses + 12);
+    P.points.resize(3 * kPoints);
+    P.obs_ranges.assign(kPoints + 1, 0);
+
+    for (uint32_t p = 0; p < kPoints; p++) {
+        const double side = (p & 1) ? 1.0 : -1.0;
+        const double theta = side * (M_PI - (2.0 + 0.2 * (p % 5)) * 2.0 * M_PI / P.intr[0]);
+        const double phi = -0.22 + 0.04 * (p % 12);
+        const double radius = 3.0 + 0.08 * p;
+        double* X = &P.points[3 * p];
+        X[0] = radius * std::cos(phi) * std::sin(theta);
+        X[1] = -radius * std::sin(phi);
+        X[2] = radius * std::cos(phi) * std::cos(theta);
+        for (uint32_t image = 0; image < kImages; image++) {
+            double px[2];
+            project(&truth_poses[6 * image], P.intr.data(), X, px);
+            P.obs_image.push_back(image);
+            P.obs_point.push_back(p);
+            P.obs_xy.push_back(px[0]);
+            P.obs_xy.push_back(px[1]);
+        }
+        P.obs_ranges[p + 1] = (uint32_t)P.obs_image.size();
+    }
+    P.num_obs = (uint32_t)P.obs_image.size();
+    P.pose_dim = 6 * kImages;
     P.total_intr = 2;
-    P.n_dim = 6;
+    P.free_intr = 0;
+    P.n_dim = P.pose_dim;
     finalizeTables(P);
+
+    P.poses[1] += 0.045;
+    P.poses[7] -= 0.038;
+    P.poses[3] += 0.025;
+    P.poses[10] -= 0.020;
+    for (uint32_t p = 0; p < kPoints; p++) {
+        P.points[3 * p] += 0.006 * ((int)(p % 3) - 1);
+        P.points[3 * p + 1] += 0.004 * ((int)(p % 5) - 2);
+    }
     return P;
 }
 
-double cost(RealCfg real) {
-    BAProblem P = makeProblem();
+int seamCrossings(const BAProblem& P) {
+    int count = 0;
+    for (uint32_t o = 0; o < P.num_obs; o++) {
+        const uint32_t image = P.obs_image[o];
+        double px[2];
+        project(&P.poses[6 * image], P.intr.data(), &P.points[3 * P.obs_point[o]], px);
+        if (std::fabs(px[0] - P.obs_xy[2 * o]) > 0.5 * P.intr[0]) count++;
+    }
+    return count;
+}
+
+double relativeMax(const std::vector<double>& a, const std::vector<double>& b) {
+    if (a.size() != b.size()) throw std::runtime_error("comparison size mismatch");
+    double diff = 0, scale = 1;
+    for (size_t i = 0; i < a.size(); i++) {
+        diff = std::max(diff, std::fabs(a[i] - b[i]));
+        scale = std::max(scale, std::max(std::fabs(a[i]), std::fabs(b[i])));
+    }
+    return diff / scale;
+}
+
+struct Result {
+    double initial = 0;
+    double final = 0;
+    std::vector<double> S, g, poses, points;
+};
+
+Result evaluate(BAProblem P, RealCfg real, const char* loss) {
     SolverOptions opt;
     opt.real = real;
+    opt.loss = loss;
+    opt.loss_param = 3.0f;
+    opt.solver = SolverSel::Dense;
+    opt.max_iters = 12;
+    opt.init_damping = 1e-2;
+    opt.rtol = 1e-10;
+    opt.patience = 6;
     opt.verbose = false;
+
     BundleSolver solver(P, opt);
     solver.init();
-    return solver.computeCost();
+    if (solver.real() != real) throw std::runtime_error("requested scalar mode unavailable");
+    Result out;
+    out.initial = solver.computeCost();
+    solver.debugAssemble((float)opt.init_damping);
+    out.S = solver.debugPackedS();
+    out.g = solver.debugG();
+    solver.solve();
+    solver.downloadParams();
+    out.final = solver.stats().final_cost;
+    out.poses = P.poses;
+    out.points = P.points;
+    return out;
+}
+
+bool variantBuilt(RealCfg real, const char* loss) {
+    const std::string name = std::string("ba_") + realCfgName(real) + "_" + loss;
+    size_t words = 0;
+    return sfm::findSpirv(name.c_str(), &words) != nullptr;
+}
+
+bool testVariant(const BAProblem& base, RealCfg real, const char* loss) {
+    if (!variantBuilt(real, loss)) {
+        std::printf("%-8s %-8s SKIP (variant not built)\n", realCfgName(real), loss);
+        return true;
+    }
+    const Result host = evaluate(base, RealCfg::CPU, loss);
+    const Result device = evaluate(base, real, loss);
+    const double cost_err = std::fabs(device.initial - host.initial) / std::max(1.0, host.initial);
+    const double S_err = relativeMax(device.S, host.S);
+    const double g_err = relativeMax(device.g, host.g);
+    const double final_err = std::fabs(device.final - host.final) / std::max(1.0, host.final);
+    const double pose_err = relativeMax(device.poses, host.poses);
+    const double point_err = relativeMax(device.points, host.points);
+    // rAtan2 is approximate; fp64 CPU/device projection parity is about 1 ppm.
+    const double assembly_tol = real == RealCfg::F32 ? 2e-5 : 2e-6;
+    const double solve_tol = real == RealCfg::F32 ? 1e-2 : 1e-5;
+    const bool descent = host.final < host.initial && device.final < device.initial;
+    const bool ok = cost_err < assembly_tol && S_err < assembly_tol && g_err < assembly_tol &&
+                    final_err < solve_tol && pose_err < solve_tol && point_err < solve_tol && descent;
+    std::printf("%-8s %-8s cost %.2e  S %.2e  g %.2e  final %.2e  pose %.2e  point %.2e  %s\n",
+                realCfgName(real), loss, cost_err, S_err, g_err, final_err, pose_err, point_err,
+                ok ? "PASS" : "FAIL");
+    return ok;
 }
 
 int run(int, char**) {
-    const double host = cost(RealCfg::CPU);
-    const double device = cost(RealCfg::F64);
-    const double error = std::max(std::fabs(host - 16.0), std::fabs(device - 16.0));
-    std::printf("equirect seam cost: host %.9f, device %.9f\n%s\n", host, device,
-                error < 1e-4 ? "PASS" : "FAIL");
-    return error < 1e-4 ? 0 : 1;
+    const BAProblem base = makeProblem();
+    const int crossings = seamCrossings(base);
+    if (crossings < 8) {
+        std::fprintf(stderr, "FAIL: only %d raw residuals cross the seam\n", crossings);
+        return 1;
+    }
+    std::printf("seam-crossing observations: %d/%u\n", crossings, base.num_obs);
+
+    bool ok = true;
+    for (const char* loss : {"trivial", "huber", "cauchy"})
+        for (RealCfg real : {RealCfg::F32, RealCfg::F64})
+            ok = testVariant(base, real, loss) && ok;
+    std::printf("%s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
 }
 
 }  // namespace

--- a/src/sfm/tests/sfm_equirect_seam_test.cpp
+++ b/src/sfm/tests/sfm_equirect_seam_test.cpp
@@ -1,0 +1,56 @@
+// Equirectangular BA residual periodicity on the host and Vulkan paths.
+#include <cmath>
+#include <cstdio>
+
+#include "sfm/ba/Problem.h"
+#include "sfm/ba/Solver.h"
+#include "sfm/tests/TestMain.h"
+
+namespace {
+
+BAProblem makeProblem() {
+    BAProblem P;
+    P.num_images = 1;
+    P.num_points = 2;
+    P.num_obs = 2;
+    P.poses.assign(6, 0.0);
+    P.intr = {640.0, 480.0};
+    P.groups = {{0, 6, 0, 9}};
+    P.image_group = {0};
+
+    const double d = 2.0 * M_PI * 2.0 / P.intr[0];
+    P.points = {std::sin(M_PI - d), 0.0, std::cos(M_PI - d),
+                std::sin(-M_PI + d), 0.0, std::cos(-M_PI + d)};
+    P.obs_image = {0, 0};
+    P.obs_point = {0, 1};
+    P.obs_xy = {2.0, 240.0, 638.0, 240.0};
+    P.obs_ranges = {0, 1, 2};
+    P.pose_dim = 6;
+    P.total_intr = 2;
+    P.n_dim = 6;
+    finalizeTables(P);
+    return P;
+}
+
+double cost(RealCfg real) {
+    BAProblem P = makeProblem();
+    SolverOptions opt;
+    opt.real = real;
+    opt.verbose = false;
+    BundleSolver solver(P, opt);
+    solver.init();
+    return solver.computeCost();
+}
+
+int run(int, char**) {
+    const double host = cost(RealCfg::CPU);
+    const double device = cost(RealCfg::F64);
+    const double error = std::max(std::fabs(host - 16.0), std::fabs(device - 16.0));
+    std::printf("equirect seam cost: host %.9f, device %.9f\n%s\n", host, device,
+                error < 1e-4 ? "PASS" : "FAIL");
+    return error < 1e-4 ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) { return sfmTestMain(argc, argv, run); }


### PR DESCRIPTION
Replaces closed #39 with seam-specific derivative, assembly and solve coverage.

## Summary

- wrap equirectangular BA x residuals to the shortest periodic displacement on CPU and Slang paths
- apply the selected periodic branch to the autodifferentiated residual so residuals and Jacobians agree
- add CPU boundary and finite-difference Jacobian regressions
- add a two-camera CPU/Vulkan regression covering cost, Schur assembly, gradient and LM solve results
- add a hand-run correctness notebook with the measured real-capture result and native CLI harness

## Automated correctness coverage

- eight CPU residual cases: both wrap directions, no-wrap cases, just-over-half-width cases and the exact half-width convention
- seam-specific CPU finite-difference Jacobian relative error: 3.265e-08
- synthetic problem: 2 cameras, 24 points, 48 observations, with 14 raw residuals crossing the seam
- RTX 4080 Vulkan matrix: float/double crossed with trivial/Huber/Cauchy
- every matrix row compares CPU and Vulkan cost, packed Schur system, gradient, final cost, poses and points
- full existing CPU BA suite: PASS

Maximum measured CPU/Vulkan relative errors were 4.93e-06 for cost, 4.96e-06 for the Schur system and 3.22e-06 for the gradient. The remaining difference is bounded by the Slang atan2 approximation.

Mutation check: disabling only the Slang periodic branch made all six variants fail. Trivial-loss relative cost error increased to 7.48e+03 and gradient error to approximately 1.02. Restoring the branch, rebuilding all six shader variants and rerunning returned every row to PASS.

## Real capture

| residual | initial cost | final cost | LM iterations |
|---|---:|---:|---:|
| non-periodic | 141,390,489 | 141,335,658 | 80 |
| periodic | 18,076,110 | 1,062 | 39 |

The ten-frame 4096x2048 capture registered 9/10 images with 1,441 points and mean/median reprojection errors of 0.532/0.337 pixels. Capture data is not redistributed; the notebook accepts an equivalent model through SS_EQUIRECT_MODEL.

## Validation

- sfm_ba_cpu_test.exe: PASS
- sfm_equirect_seam_test.exe: PASS for all six built variants
- notebook JSON, code compilation and complete execution: PASS
- tools/check_private_paths.sh: PASS
- git diff --check origin/master...HEAD: PASS

The focused SfM targets compile and link with SS_SFM_REALS=float;double and all three losses. The complete application build later stops in unchanged VulkanContext.cpp because the local Vulkan 1.3.231 headers predate VK_EXT_layer_settings; this is outside the PR diff.