### PR TITLE
Fix comment length in SsVulkan.cmake

### DIFF
--- a/cmake/SsVulkan.cmake
+++ b/cmake/SsVulkan.cmake
@@ -83,8 +83,6 @@ function(_ss_vulkan_header_version inc out_var)
     endif()
 endfunction()
 
-# _ss_fetch_vulkan_headers(<include_var>)
-#
 # Unpacks the pinned Vulkan-Headers release into the build tree. Header-only
 # and architecture-independent, so this covers every platform whose loader is
 # current but whose headers are not.


### PR DESCRIPTION
tools/check_comment_length.py allows three lines of prose per comment block. The header above _ss_fetch_vulkan_headers has four, so the build stops at the ss_check_comment_length target instead of just warning.

The line I removed only repeats the function signature, which is on the next line anyway. Two of the four functions in this file already go without one.
