### PR TITLE
sfm: optional metric gauge from camera positions or EXIF GPS

### DIFF
--- a/docs/notes/sfm-design.md
+++ b/docs/notes/sfm-design.md
@@ -88,3 +88,4 @@ be re-derived or re-attempted: D25, D26, D27, D11, D16, D47, D50, D45, D46.
 | D71 | The audit's repair is off: guessing a pose from evidence weaker than registration demands cost a 5356-image capture 28 points of AUC and the largest bill of any finishing pass |
 | D72 | Distortion coefficients can be held through mapping and recovered in the finishing pass, like the principal point -- and holding them holds the principal point too, because the free intrinsics are a prefix |
 | D73 | Per-image intrinsics as a finishing pass: reconstruct with the cameras shared, then split them one per image for a last bundle adjustment, with no clamp back to the group |
+| D74 | The metric gauge is fixed where the model is written, from paired camera positions; a fit that fails its uncertainty gates is reported and refused, never approximated |

--- a/docs/notes/sfm-design.md
+++ b/docs/notes/sfm-design.md
@@ -88,4 +88,4 @@ be re-derived or re-attempted: D25, D26, D27, D11, D16, D47, D50, D45, D46.
 | D71 | The audit's repair is off: guessing a pose from evidence weaker than registration demands cost a 5356-image capture 28 points of AUC and the largest bill of any finishing pass |
 | D72 | Distortion coefficients can be held through mapping and recovered in the finishing pass, like the principal point -- and holding them holds the principal point too, because the free intrinsics are a prefix |
 | D73 | Per-image intrinsics as a finishing pass: reconstruct with the cameras shared, then split them one per image for a last bundle adjustment, with no clamp back to the group |
-| D74 | The metric gauge is fixed where the model is written, from paired camera positions; a fit that fails its uncertainty gates is reported and refused, never approximated |
+| D74 | The metric gauge is fixed where the model is written, from paired camera positions, and what refuses a fit is geometry -- spread and collinearity -- not the residual-derived uncertainties, which assume uncorrelated error and were measured under-stating a correlated reference by 3.9-4.5x |

--- a/src/app/cli/sfm_main.cpp
+++ b/src/app/cli/sfm_main.cpp
@@ -56,6 +56,7 @@
 #include "sfm/geometry/TwoView.h"
 #include "sfm/map/Assemble.h"
 #include "sfm/map/Mapper.h"
+#include "sfm/map/MetricGauge.h"
 #include "sfm/map/Orient.h"
 #include "sfm/map/Merge.h"
 
@@ -233,6 +234,7 @@ static void printCommandHelp(const CommandInfo& c) {
         std::fprintf(out, "  1  %s\n", H::exit_1.get());
         std::fprintf(out, "  2  %s\n", H::exit_2.get());
         std::fprintf(out, "  3  %s\n", H::exit_3.get());
+        std::fprintf(out, "  4  %s\n", H::exit_4.get());
     }
 }
 
@@ -460,6 +462,97 @@ static void orientModels(std::vector<Reconstruction>& models, bool enabled, bool
         if (verbose)
             L::err(Tag::Orient, M::orient_done, {(long long)i, L::num(T.scale, 4)});
     }
+}
+
+// Why a metric fit was refused, with the numbers, so one line is a complete
+// bug report.
+static std::string metricReason(const MetricFit& f) {
+    switch (f.reason) {
+        case MetricFail::Pairs:
+            return spirula::i18n::format(M::metric_fail_pairs, {(long long)f.n});
+        case MetricFail::Spread:
+            return spirula::i18n::format(M::metric_fail_spread, {L::num(f.spread, 3)});
+        case MetricFail::Inliers:
+            return spirula::i18n::format(M::metric_fail_inliers,
+                                {L::num(f.max_error, 3), (long long)f.inliers,
+                                 (long long)f.n});
+        case MetricFail::Scale:
+            return spirula::i18n::format(M::metric_fail_scale,
+                                {L::num(f.scale_unc, 3), L::num(kMetricMaxScaleUncPct, 1)});
+        case MetricFail::Rotation:
+            return spirula::i18n::format(M::metric_fail_rotation,
+                                {L::num(f.rot_unc_deg, 2), L::num(kMetricMaxRotUncDeg, 1)});
+        case MetricFail::None: break;
+    }
+    return {};
+}
+
+// The gauge every finished model is written in: metric when a reference in
+// metres was given and the fit can carry it, the ordinary orient frame
+// otherwise. False when a metric frame was asked for and not delivered.
+static bool fixGauge(std::vector<Reconstruction>& models, const SfmConfig& cfg,
+                     const std::string& imagedir, bool verbose) {
+    const bool gps = cfg.metric_gps;
+    const bool file = !cfg.metric_positions.empty();
+    if (!gps && !file) {
+        orientModels(models, cfg.orient, verbose);
+        return true;
+    }
+    std::map<std::string, Vec3> positions;
+    if (file) {
+        std::string err;
+        if (!readMetricPositions(cfg.metric_positions, positions, err)) {
+            L::fail(Tag::Orient, M::metric_positions_bad, {cfg.metric_positions, err});
+            orientModels(models, cfg.orient, verbose);
+            return false;
+        }
+    }
+    bool all = true;
+    for (size_t i = 0; i < models.size(); i++) {
+        MetricRef ref;
+        if (file) {
+            const MetricPairCounts pc = pairMetricRef(models[i], positions, ref);
+            L::out(Tag::Orient, M::metric_matched,
+                   {(long long)pc.matched, (long long)(pc.matched + pc.unmatched_model),
+                    (long long)pc.unmatched_file});
+        } else {
+            const MetricGpsCounts gc = metricRefFromGps(models[i], imagedir, ref);
+            L::out(Tag::Orient, M::metric_gps_read,
+                   {(long long)gc.matched, (long long)(gc.matched + gc.no_gps),
+                    (long long)gc.no_alt});
+        }
+        const MetricFit fit = fitMetricGauge(ref, cfg.metric_max_error);
+        if (!fit.ok) {
+            all = false;
+            if (cfg.orient) orientModel(models[i]);
+            L::fail(Tag::Orient, M::metric_failed, {(long long)i, metricReason(fit)});
+            continue;
+        }
+        applySim3(models[i], fit.T);
+        L::out(Tag::Orient, M::metric_done,
+               {(long long)i,
+                spirula::i18n::format(gps ? M::metric_source_gps : M::metric_source_positions, {}),
+                L::num(fit.T.scale, 6), L::num(fit.max_error, 3), (long long)fit.inliers,
+                (long long)fit.n, L::num(fit.rms, 4), L::num(fit.scale_unc, 3),
+                L::num(fit.rot_unc_deg, 3)});
+        if (!verbose) continue;
+        // A drifting altitude offset is absorbed by the rotation as a tilt and
+        // leaves the RMS looking fine; these two numbers are what show it.
+        double e = 0, n = 0, u = 0;
+        for (size_t k = 0; k < ref.centres.size(); k++) {
+            if (!fit.inlier_mask[k]) continue;
+            const Vec3 r = ref.targets[k] - transformPoint(fit.T, ref.centres[k]);
+            e += r.x * r.x;
+            n += r.y * r.y;
+            u += r.z * r.z;
+        }
+        const double m = std::max(fit.inliers, 1);
+        L::err(Tag::Orient, M::metric_axes,
+               {L::num(std::sqrt(e / m), 4), L::num(std::sqrt(n / m), 4),
+                L::num(std::sqrt(u / m), 4),
+                L::num(metricUpDisagreementDeg(models[i]), 2)});
+    }
+    return all;
 }
 
 // An EXR carries its own colour space. Reading it needs no declaration -- the
@@ -1839,11 +1932,11 @@ static int cmdMap(int argc, char** argv) {
                 (long long)db.images.size()});
         printExtraModels(models, feats);
     }
-    orientModels(models, cfg.orient, opt.verbose);
+    const bool map_metric = fixGauge(models, cfg, cfg.image_dir, opt.verbose);
     recolorPoints(models, cfg);
     splitCamerasBySize(models, feats);
     if (!output.empty()) writeModels(models, output, opt.verbose);
-    return 0;
+    return map_metric ? 0 : 4;
 }
 
 // -----------------------------------------------------------------------
@@ -1932,7 +2025,7 @@ static int cmdMerge(int argc, char** argv) {
         L::out(Tag::Merge, M::merge_survived,
                {(long long)covered_after, (long long)covered_before});
 
-    orientModels(models, cfg.orient, mo.verbose);
+    const bool merge_metric = fixGauge(models, cfg, cfg.image_dir, mo.verbose);
     recolorPoints(models, cfg);
     writeModels(models, fs::path(output), mo.verbose);
     // In place, the models that were absorbed must not stay behind as stale
@@ -1949,7 +2042,7 @@ static int cmdMerge(int argc, char** argv) {
                 L::out(Tag::Merge, M::merge_removed_absorbed, {d.string()});
             }
         }
-    return 0;
+    return merge_metric ? 0 : 4;
 }
 
 // -----------------------------------------------------------------------
@@ -2148,7 +2241,7 @@ static int cmdAuto(int argc, char** argv) {
     }
 
     resolveImageNames(models, imagedir);
-    orientModels(models, cfg.orient, verbose);
+    const bool auto_metric = fixGauge(models, cfg, imagedir, verbose);
     recolorPoints(models, cfg);
     // Before the split: the summary reports what was estimated, and the file's
     // one camera per frame size is not that.
@@ -2211,6 +2304,12 @@ static int cmdAuto(int argc, char** argv) {
     if (frac < 0.5 || mean > 2.0) {
         L::out(Tag::Run, M::result_partial, {L::num(100 * frac, 0), L::num(mean, 2)});
         return 3;
+    }
+    // A sound model in the wrong gauge is still a sound model, so the metric
+    // verdict comes after the ones about the reconstruction itself.
+    if (!auto_metric) {
+        L::out(Tag::Run, M::result_not_metric);
+        return 4;
     }
     L::out(Tag::Run, M::result_ok, {L::num(100 * frac, 0), L::num(mean, 2)});
     return 0;

--- a/src/app/cli/sfm_main.cpp
+++ b/src/app/cli/sfm_main.cpp
@@ -476,12 +476,11 @@ static std::string metricReason(const MetricFit& f) {
             return spirula::i18n::format(M::metric_fail_inliers,
                                 {L::num(f.max_error, 3), (long long)f.inliers,
                                  (long long)f.n});
-        case MetricFail::Scale:
-            return spirula::i18n::format(M::metric_fail_scale,
-                                {L::num(f.scale_unc, 3), L::num(kMetricMaxScaleUncPct, 1)});
-        case MetricFail::Rotation:
-            return spirula::i18n::format(M::metric_fail_rotation,
-                                {L::num(f.rot_unc_deg, 2), L::num(kMetricMaxRotUncDeg, 1)});
+        case MetricFail::Collinear:
+            return spirula::i18n::format(
+                M::metric_fail_collinear,
+                {L::num(100.0 * f.perp_frac, 2), L::num(100.0 * kMetricMinPerpFraction, 1),
+                 L::num(f.perp_frac > 0 ? 1.0 / f.perp_frac : 0.0, 0)});
         case MetricFail::None: break;
     }
     return {};

--- a/src/i18n/catalog/Sfm.h
+++ b/src/i18n/catalog/Sfm.h
@@ -2388,6 +2388,248 @@ SS_MSG(merge_rebundled,
     TR("model {0} yeniden dengelendi (maliyet {1}); elenen gözlem: {2}, "
        "nokta: {3}; kalan nokta: {4}"));
 
+SS_MSG(metric_source_gps,
+    EN("EXIF GPS"),        JA("EXIF の GPS"),  ZH_HANS("EXIF GPS"), ZH_HANT("EXIF GPS"),
+    KO("EXIF GPS"),        DE("EXIF-GPS"),     FR("le GPS EXIF"),   ES("el GPS EXIF"),
+    PT("o GPS EXIF"),      IT("il GPS EXIF"),  NL("de EXIF-GPS"),   RU("GPS из EXIF"),
+    TR("EXIF GPS"));
+
+SS_MSG(metric_source_positions,
+    EN("the positions file"), JA("位置ファイル"), ZH_HANS("位置文件"), ZH_HANT("位置檔"),
+    KO("위치 파일"),          DE("die Positionsdatei"), FR("le fichier de positions"),
+    ES("el archivo de posiciones"), PT("o ficheiro de posições"),
+    IT("il file di posizioni"), NL("het positiebestand"), RU("файл позиций"),
+    TR("konum dosyası"));
+
+SS_MSG(metric_done,
+    EN("Model {0}: metric frame from {1} -- scale {2}, cameras within {3} m: {4}/{5}, "
+       "RMS {6} m, scale uncertainty {7}%, orientation uncertainty {8} deg"),
+    JA("モデル {0}: {1} によるメートル座標系 -- 縮尺 {2}、{3} m 以内のカメラ: {4}/{5}、"
+       "RMS {6} m、縮尺の不確かさ {7}%、向きの不確かさ {8} 度"),
+    ZH_HANS("模型 {0}: 由{1}确定的米制坐标系 -- 缩放 {2}，{3} m 以内的相机: {4}/{5}，"
+            "RMS {6} m，缩放不确定度 {7}%，朝向不确定度 {8} 度"),
+    ZH_HANT("模型 {0}: 由{1}確定的公尺座標系 -- 縮放 {2}，{3} m 以內的相機: {4}/{5}，"
+            "RMS {6} m，縮放不確定度 {7}%，朝向不確定度 {8} 度"),
+    KO("모델 {0}: {1} 기준 미터 좌표계 -- 배율 {2}, {3} m 이내 카메라: {4}/{5}, "
+       "RMS {6} m, 배율 불확실도 {7}%, 방향 불확실도 {8} 도"),
+    DE("Modell {0}: metrischer Rahmen aus {1} -- Maßstab {2}, Kameras innerhalb {3} m: "
+       "{4}/{5}, RMS {6} m, Maßstabsunsicherheit {7}%, Orientierungsunsicherheit {8} Grad"),
+    FR("Modèle {0} : repère métrique d'après {1} -- échelle {2}, caméras à moins de {3} m : "
+       "{4}/{5}, RMS {6} m, incertitude d'échelle {7}%, incertitude d'orientation {8} degrés"),
+    ES("Modelo {0}: marco métrico a partir de {1} -- escala {2}, cámaras dentro de {3} m: "
+       "{4}/{5}, RMS {6} m, incertidumbre de escala {7}%, incertidumbre de orientación {8} grados"),
+    PT("Modelo {0}: referencial métrico a partir de {1} -- escala {2}, câmeras dentro de {3} m: "
+       "{4}/{5}, RMS {6} m, incerteza de escala {7}%, incerteza de orientação {8} graus"),
+    IT("Modello {0}: sistema metrico da {1} -- scala {2}, camere entro {3} m: {4}/{5}, "
+       "RMS {6} m, incertezza di scala {7}%, incertezza di orientamento {8} gradi"),
+    NL("Model {0}: metrisch stelsel uit {1} -- schaal {2}, camera's binnen {3} m: {4}/{5}, "
+       "RMS {6} m, schaalonzekerheid {7}%, oriëntatieonzekerheid {8} graden"),
+    RU("Модель {0}: метрическая система по источнику {1} -- масштаб {2}, камер в пределах "
+       "{3} м: {4}/{5}, СКО {6} м, неопределённость масштаба {7}%, неопределённость "
+       "ориентации {8} градусов"),
+    TR("Model {0}: {1} kaynaklı metrik çerçeve -- ölçek {2}, {3} m içindeki kameralar: "
+       "{4}/{5}, RMS {6} m, ölçek belirsizliği {7}%, yönelim belirsizliği {8} derece"));
+
+SS_MSG(metric_failed,
+    EN("Model {0}: metric frame NOT applied, written in the normalized frame instead -- {1}"),
+    JA("モデル {0}: メートル座標系は適用せず、正規化座標系で書き出しました -- {1}"),
+    ZH_HANS("模型 {0}: 未应用米制坐标系，改为按归一化坐标系写出 -- {1}"),
+    ZH_HANT("模型 {0}: 未套用公尺座標系，改為按正規化座標系寫出 -- {1}"),
+    KO("모델 {0}: 미터 좌표계를 적용하지 않고 정규화 좌표계로 썼습니다 -- {1}"),
+    DE("Modell {0}: metrischer Rahmen NICHT angewandt, stattdessen im normalisierten "
+       "Rahmen geschrieben -- {1}"),
+    FR("Modèle {0} : repère métrique NON appliqué, écrit dans le repère normalisé -- {1}"),
+    ES("Modelo {0}: marco métrico NO aplicado, escrito en el marco normalizado -- {1}"),
+    PT("Modelo {0}: referencial métrico NÃO aplicado, escrito no referencial normalizado -- {1}"),
+    IT("Modello {0}: sistema metrico NON applicato, scritto nel sistema normalizzato -- {1}"),
+    NL("Model {0}: metrisch stelsel NIET toegepast, in het genormaliseerde stelsel "
+       "geschreven -- {1}"),
+    RU("Модель {0}: метрическая система НЕ применена, записано в нормализованной "
+       "системе -- {1}"),
+    TR("Model {0}: metrik çerçeve UYGULANMADI, normalize çerçevede yazıldı -- {1}"));
+
+SS_MSG(metric_fail_pairs,
+    EN("cameras with a metric position: {0}, need 3"),
+    JA("メートル位置を持つカメラ: {0}、3 台必要です"),
+    ZH_HANS("有米制位置的相机: {0}，需要 3 台"),
+    ZH_HANT("有公尺位置的相機: {0}，需要 3 台"),
+    KO("미터 위치가 있는 카메라: {0}, 3대가 필요합니다"),
+    DE("Kameras mit metrischer Position: {0}, benötigt werden 3"),
+    FR("caméras avec une position métrique : {0}, il en faut 3"),
+    ES("cámaras con posición métrica: {0}, hacen falta 3"),
+    PT("câmeras com posição métrica: {0}, são precisas 3"),
+    IT("camere con una posizione metrica: {0}, ne servono 3"),
+    NL("camera's met een metrische positie: {0}, er zijn er 3 nodig"),
+    RU("камер с метрической позицией: {0}, нужно 3"),
+    TR("metrik konumu olan kamera: {0}, 3 gerekli"));
+
+SS_MSG(metric_fail_spread,
+    EN("the metric positions do not spread out (radius {0} m); nothing to fit a scale to"),
+    JA("メートル位置に広がりがありません (半径 {0} m)。縮尺を合わせる手がかりがありません"),
+    ZH_HANS("米制位置没有展开 (半径 {0} m)，无从拟合缩放"),
+    ZH_HANT("公尺位置沒有展開 (半徑 {0} m)，無從擬合縮放"),
+    KO("미터 위치가 퍼져 있지 않습니다 (반지름 {0} m). 배율을 맞출 근거가 없습니다"),
+    DE("die metrischen Positionen streuen nicht (Radius {0} m); nichts, woran ein "
+       "Maßstab passt"),
+    FR("les positions métriques ne s'étalent pas (rayon {0} m) ; rien pour ajuster une échelle"),
+    ES("las posiciones métricas no se dispersan (radio {0} m); nada a lo que ajustar una escala"),
+    PT("as posições métricas não se espalham (raio {0} m); nada a que ajustar uma escala"),
+    IT("le posizioni metriche non si distribuiscono (raggio {0} m); niente su cui "
+       "stimare una scala"),
+    NL("de metrische posities spreiden niet (straal {0} m); niets om een schaal op te passen"),
+    RU("метрические позиции не разнесены (радиус {0} м); не к чему подгонять масштаб"),
+    TR("metrik konumlar yayılmıyor (yarıçap {0} m); ölçeği oturtacak bir şey yok"));
+
+SS_MSG(metric_fail_inliers,
+    EN("cameras within {0} m of the fit: {1}/{2}, need half"),
+    JA("当てはめから {0} m 以内のカメラ: {1}/{2}、半数必要です"),
+    ZH_HANS("与拟合相差 {0} m 以内的相机: {1}/{2}，需要半数"),
+    ZH_HANT("與擬合相差 {0} m 以內的相機: {1}/{2}，需要半數"),
+    KO("맞춤에서 {0} m 이내인 카메라: {1}/{2}, 절반이 필요합니다"),
+    DE("Kameras innerhalb {0} m der Anpassung: {1}/{2}, nötig ist die Hälfte"),
+    FR("caméras à moins de {0} m de l'ajustement : {1}/{2}, il en faut la moitié"),
+    ES("cámaras dentro de {0} m del ajuste: {1}/{2}, hace falta la mitad"),
+    PT("câmeras dentro de {0} m do ajuste: {1}/{2}, é precisa metade"),
+    IT("camere entro {0} m dalla stima: {1}/{2}, ne serve la metà"),
+    NL("camera's binnen {0} m van de fit: {1}/{2}, de helft is nodig"),
+    RU("камер в пределах {0} м от подгонки: {1}/{2}, нужна половина"),
+    TR("uyuma {0} m içinde olan kamera: {1}/{2}, yarısı gerekli"));
+
+SS_MSG(metric_fail_scale,
+    EN("scale uncertainty {0}% is above {1}%: the positions are too noisy for a capture "
+       "this size"),
+    JA("縮尺の不確かさ {0}% が {1}% を超えています。この規模の撮影には位置の誤差が大きすぎます"),
+    ZH_HANS("缩放不确定度 {0}% 超过 {1}%: 对这个尺度的采集来说位置噪声太大"),
+    ZH_HANT("縮放不確定度 {0}% 超過 {1}%: 對這個尺度的拍攝來說位置雜訊太大"),
+    KO("배율 불확실도 {0}% 가 {1}% 를 넘습니다. 이 규모의 촬영에는 위치 오차가 너무 큽니다"),
+    DE("Maßstabsunsicherheit {0}% liegt über {1}%: die Positionen sind für eine Aufnahme "
+       "dieser Größe zu verrauscht"),
+    FR("l'incertitude d'échelle {0}% dépasse {1}% : les positions sont trop bruitées pour "
+       "une prise de cette taille"),
+    ES("la incertidumbre de escala {0}% supera {1}%: las posiciones tienen demasiado ruido "
+       "para una toma de este tamaño"),
+    PT("a incerteza de escala {0}% ultrapassa {1}%: as posições têm demasiado ruído para "
+       "uma captura deste tamanho"),
+    IT("l'incertezza di scala {0}% supera {1}%: le posizioni sono troppo rumorose per una "
+       "ripresa di queste dimensioni"),
+    NL("schaalonzekerheid {0}% ligt boven {1}%: de posities zijn te ruizig voor een opname "
+       "van deze omvang"),
+    RU("неопределённость масштаба {0}% выше {1}%: позиции слишком шумные для съёмки "
+       "такого размера"),
+    TR("ölçek belirsizliği {0}%, {1}% üzerinde: konumlar bu boyuttaki bir çekim için "
+       "fazla gürültülü"));
+
+SS_MSG(metric_fail_rotation,
+    EN("orientation uncertainty {0} deg is above {1}: the cameras lie along a line"),
+    JA("向きの不確かさ {0} 度が {1} を超えています。カメラが一直線上に並んでいます"),
+    ZH_HANS("朝向不确定度 {0} 度超过 {1}: 相机排成了一条直线"),
+    ZH_HANT("朝向不確定度 {0} 度超過 {1}: 相機排成了一條直線"),
+    KO("방향 불확실도 {0} 도가 {1} 을 넘습니다. 카메라가 일직선에 놓여 있습니다"),
+    DE("Orientierungsunsicherheit {0} Grad liegt über {1}: die Kameras liegen auf einer Linie"),
+    FR("l'incertitude d'orientation {0} degrés dépasse {1} : les caméras sont alignées"),
+    ES("la incertidumbre de orientación {0} grados supera {1}: las cámaras están alineadas"),
+    PT("a incerteza de orientação {0} graus ultrapassa {1}: as câmeras estão alinhadas"),
+    IT("l'incertezza di orientamento {0} gradi supera {1}: le camere sono allineate"),
+    NL("oriëntatieonzekerheid {0} graden ligt boven {1}: de camera's liggen op één lijn"),
+    RU("неопределённость ориентации {0} градусов выше {1}: камеры лежат на одной прямой"),
+    TR("yönelim belirsizliği {0} derece, {1} üzerinde: kameralar tek bir doğru üzerinde"));
+
+SS_MSG(metric_matched,
+    EN("Positions file: matched {0}/{1} cameras (names not in the model: {2})"),
+    JA("位置ファイル: {0}/{1} 台のカメラと対応しました (モデルにない名前: {2})"),
+    ZH_HANS("位置文件: 匹配了 {0}/{1} 台相机 (模型中没有的名字: {2})"),
+    ZH_HANT("位置檔: 對應了 {0}/{1} 台相機 (模型中沒有的名稱: {2})"),
+    KO("위치 파일: 카메라 {0}/{1} 대와 대응했습니다 (모델에 없는 이름: {2})"),
+    DE("Positionsdatei: {0}/{1} Kameras zugeordnet (Namen, die das Modell nicht hat: {2})"),
+    FR("Fichier de positions : {0}/{1} caméras appariées (noms absents du modèle : {2})"),
+    ES("Archivo de posiciones: {0}/{1} cámaras emparejadas (nombres que no están en el "
+       "modelo: {2})"),
+    PT("Ficheiro de posições: {0}/{1} câmeras emparelhadas (nomes que o modelo não tem: {2})"),
+    IT("File di posizioni: {0}/{1} camere abbinate (nomi assenti dal modello: {2})"),
+    NL("Positiebestand: {0}/{1} camera's gekoppeld (namen die het model niet heeft: {2})"),
+    RU("Файл позиций: сопоставлено камер {0}/{1} (имён нет в модели: {2})"),
+    TR("Konum dosyası: {0}/{1} kamera eşleşti (modelde olmayan adlar: {2})"));
+
+SS_MSG(metric_gps_read,
+    EN("EXIF GPS: {0}/{1} cameras carry a fix ({2} of them without an altitude)"),
+    JA("EXIF の GPS: {0}/{1} 台のカメラに測位があります (うち高度なし: {2})"),
+    ZH_HANS("EXIF GPS: {0}/{1} 台相机带有定位 (其中没有高度的: {2})"),
+    ZH_HANT("EXIF GPS: {0}/{1} 台相機帶有定位 (其中沒有高度的: {2})"),
+    KO("EXIF GPS: 카메라 {0}/{1} 대에 측위가 있습니다 (그중 고도 없음: {2})"),
+    DE("EXIF-GPS: {0}/{1} Kameras haben eine Position ({2} davon ohne Höhe)"),
+    FR("GPS EXIF : {0}/{1} caméras ont un point ({2} d'entre elles sans altitude)"),
+    ES("GPS EXIF: {0}/{1} cámaras traen una posición ({2} de ellas sin altitud)"),
+    PT("GPS EXIF: {0}/{1} câmeras trazem uma posição ({2} delas sem altitude)"),
+    IT("GPS EXIF: {0}/{1} camere hanno un punto ({2} di esse senza quota)"),
+    NL("EXIF-GPS: {0}/{1} camera's hebben een fix ({2} daarvan zonder hoogte)"),
+    RU("GPS из EXIF: у {0}/{1} камер есть отсчёт ({2} из них без высоты)"),
+    TR("EXIF GPS: {0}/{1} kamerada konum var ({2} tanesi yükseklik olmadan)"));
+
+SS_MSG(metric_axes,
+    EN("Residual RMS east/north/up: {0}/{1}/{2} m; fitted up axis vs the cameras' "
+       "mean up: {3} deg"),
+    JA("残差 RMS 東/北/上: {0}/{1}/{2} m。当てはめた上方向とカメラの平均上方向の差: {3} 度"),
+    ZH_HANS("残差 RMS 东/北/上: {0}/{1}/{2} m; 拟合的上方向与相机平均上方向相差 {3} 度"),
+    ZH_HANT("殘差 RMS 東/北/上: {0}/{1}/{2} m; 擬合的上方向與相機平均上方向相差 {3} 度"),
+    KO("잔차 RMS 동/북/상: {0}/{1}/{2} m; 맞춘 상 방향과 카메라 평균 상 방향 차이: {3} 도"),
+    DE("Residuen-RMS Ost/Nord/Oben: {0}/{1}/{2} m; angepasste Hochachse gegen die mittlere "
+       "Hochachse der Kameras: {3} Grad"),
+    FR("RMS des résidus est/nord/haut : {0}/{1}/{2} m ; axe vertical ajusté contre le haut "
+       "moyen des caméras : {3} degrés"),
+    ES("RMS de residuos este/norte/arriba: {0}/{1}/{2} m; eje vertical ajustado frente al "
+       "arriba medio de las cámaras: {3} grados"),
+    PT("RMS dos resíduos este/norte/cima: {0}/{1}/{2} m; eixo vertical ajustado contra o "
+       "cima médio das câmeras: {3} graus"),
+    IT("RMS dei residui est/nord/alto: {0}/{1}/{2} m; asse verticale stimato rispetto "
+       "all'alto medio delle camere: {3} gradi"),
+    NL("Residu-RMS oost/noord/omhoog: {0}/{1}/{2} m; gefitte omhoog-as tegen de gemiddelde "
+       "omhoog van de camera's: {3} graden"),
+    RU("СКО остатков восток/север/верх: {0}/{1}/{2} м; подогнанная вертикаль против средней "
+       "вертикали камер: {3} градусов"),
+    TR("Artık RMS doğu/kuzey/yukarı: {0}/{1}/{2} m; oturtulan yukarı ekseni kameraların "
+       "ortalama yukarısına karşı: {3} derece"));
+
+SS_MSG(metric_positions_bad,
+    EN("Positions file {0} cannot be read: {1}"),
+    JA("位置ファイル {0} を読み取れません: {1}"),
+    ZH_HANS("无法读取位置文件 {0}: {1}"),
+    ZH_HANT("無法讀取位置檔 {0}: {1}"),
+    KO("위치 파일 {0} 을 읽을 수 없습니다: {1}"),
+    DE("Positionsdatei {0} lässt sich nicht lesen: {1}"),
+    FR("Le fichier de positions {0} est illisible : {1}"),
+    ES("No se puede leer el archivo de posiciones {0}: {1}"),
+    PT("Não é possível ler o ficheiro de posições {0}: {1}"),
+    IT("Impossibile leggere il file di posizioni {0}: {1}"),
+    NL("Positiebestand {0} kan niet gelezen worden: {1}"),
+    RU("Не удаётся прочитать файл позиций {0}: {1}"),
+    TR("Konum dosyası {0} okunamıyor: {1}"));
+
+SS_MSG(result_not_metric,
+    EN("RESULT: NOT METRIC -- the model is sound but the metric frame could not be fitted; "
+       "see the line above"),
+    JA("結果: メートル座標系なし -- モデル自体は健全ですが、メートル座標系を当てはめられません"
+       "でした。上の行を参照してください"),
+    ZH_HANS("结果: 非米制 -- 模型本身没问题，但无法拟合米制坐标系; 见上一行"),
+    ZH_HANT("結果: 非公尺 -- 模型本身沒問題，但無法擬合公尺座標系; 見上一行"),
+    KO("결과: 미터 좌표계 아님 -- 모델 자체는 온전하지만 미터 좌표계를 맞추지 못했습니다. "
+       "위 줄을 보십시오"),
+    DE("ERGEBNIS: NICHT METRISCH -- das Modell ist in Ordnung, aber der metrische Rahmen "
+       "ließ sich nicht anpassen; siehe die Zeile darüber"),
+    FR("RÉSULTAT : NON MÉTRIQUE -- le modèle est sain mais le repère métrique n'a pas pu "
+       "être ajusté ; voir la ligne ci-dessus"),
+    ES("RESULTADO: NO MÉTRICO -- el modelo está bien pero no se pudo ajustar el marco "
+       "métrico; vea la línea anterior"),
+    PT("RESULTADO: NÃO MÉTRICO -- o modelo está bem mas o referencial métrico não pôde ser "
+       "ajustado; veja a linha acima"),
+    IT("RISULTATO: NON METRICO -- il modello è valido ma il sistema metrico non si è potuto "
+       "stimare; vedere la riga sopra"),
+    NL("RESULTAAT: NIET METRISCH -- het model deugt, maar het metrische stelsel kon niet "
+       "gefit worden; zie de regel hierboven"),
+    RU("РЕЗУЛЬТАТ: НЕ МЕТРИЧЕСКИЙ -- модель исправна, но метрическую систему подогнать не "
+       "удалось; см. строку выше"),
+    TR("SONUÇ: METRİK DEĞİL -- model sağlam ama metrik çerçeve oturtulamadı; üstteki "
+       "satıra bakın"));
+
 }  // namespace sfm
 }  // namespace msg
 }  // namespace i18n

--- a/src/i18n/catalog/Sfm.h
+++ b/src/i18n/catalog/Sfm.h
@@ -2566,28 +2566,28 @@ SS_MSG(metric_gps_read,
     TR("EXIF GPS: {0}/{1} kamerada konum var ({2} tanesi yükseklik olmadan)"));
 
 SS_MSG(metric_axes,
-    EN("Residual RMS east/north/up: {0}/{1}/{2} m; fitted up axis vs the cameras' "
-       "mean up: {3} deg"),
-    JA("残差 RMS 東/北/上: {0}/{1}/{2} m。当てはめた上方向とカメラの平均上方向の差: {3} 度"),
-    ZH_HANS("残差 RMS 东/北/上: {0}/{1}/{2} m; 拟合的上方向与相机平均上方向相差 {3} 度"),
-    ZH_HANT("殘差 RMS 東/北/上: {0}/{1}/{2} m; 擬合的上方向與相機平均上方向相差 {3} 度"),
-    KO("잔차 RMS 동/북/상: {0}/{1}/{2} m; 맞춘 상 방향과 카메라 평균 상 방향 차이: {3} 도"),
-    DE("Residuen-RMS Ost/Nord/Oben: {0}/{1}/{2} m; angepasste Hochachse gegen die mittlere "
-       "Hochachse der Kameras: {3} Grad"),
-    FR("RMS des résidus est/nord/haut : {0}/{1}/{2} m ; axe vertical ajusté contre le haut "
-       "moyen des caméras : {3} degrés"),
-    ES("RMS de residuos este/norte/arriba: {0}/{1}/{2} m; eje vertical ajustado frente al "
-       "arriba medio de las cámaras: {3} grados"),
-    PT("RMS dos resíduos este/norte/cima: {0}/{1}/{2} m; eixo vertical ajustado contra o "
-       "cima médio das câmeras: {3} graus"),
-    IT("RMS dei residui est/nord/alto: {0}/{1}/{2} m; asse verticale stimato rispetto "
-       "all'alto medio delle camere: {3} gradi"),
-    NL("Residu-RMS oost/noord/omhoog: {0}/{1}/{2} m; gefitte omhoog-as tegen de gemiddelde "
-       "omhoog van de camera's: {3} graden"),
-    RU("СКО остатков восток/север/верх: {0}/{1}/{2} м; подогнанная вертикаль против средней "
-       "вертикали камер: {3} градусов"),
-    TR("Artık RMS doğu/kuzey/yukarı: {0}/{1}/{2} m; oturtulan yukarı ekseni kameraların "
-       "ortalama yukarısına karşı: {3} derece"));
+    EN("Residual RMS per reference axis: {0}/{1}/{2} m; fitted up axis vs the "
+       "cameras' mean up: {3} deg"),
+    JA("基準軸ごとの残差 RMS: {0}/{1}/{2} m。当てはめた上方向とカメラの平均上方向の差: {3} 度"),
+    ZH_HANS("按参考轴的残差 RMS: {0}/{1}/{2} m; 拟合的上方向与相机平均上方向相差 {3} 度"),
+    ZH_HANT("按參考軸的殘差 RMS: {0}/{1}/{2} m; 擬合的上方向與相機平均上方向相差 {3} 度"),
+    KO("기준 축별 잔차 RMS: {0}/{1}/{2} m; 맞춘 상 방향과 카메라 평균 상 방향 차이: {3} 도"),
+    DE("Residuen-RMS je Referenzachse: {0}/{1}/{2} m; angepasste Hochachse gegen die "
+       "mittlere Hochachse der Kameras: {3} Grad"),
+    FR("RMS des résidus par axe de référence : {0}/{1}/{2} m ; axe vertical ajusté "
+       "contre le haut moyen des caméras : {3} degrés"),
+    ES("RMS de residuos por eje de referencia: {0}/{1}/{2} m; eje vertical ajustado "
+       "frente al arriba medio de las cámaras: {3} grados"),
+    PT("RMS dos resíduos por eixo de referência: {0}/{1}/{2} m; eixo vertical ajustado "
+       "contra o cima médio das câmeras: {3} graus"),
+    IT("RMS dei residui per asse di riferimento: {0}/{1}/{2} m; asse verticale stimato "
+       "rispetto all'alto medio delle camere: {3} gradi"),
+    NL("Residu-RMS per referentie-as: {0}/{1}/{2} m; gefitte omhoog-as tegen de "
+       "gemiddelde omhoog van de camera's: {3} graden"),
+    RU("СКО остатков по каждой оси эталона: {0}/{1}/{2} м; подогнанная вертикаль против "
+       "средней вертикали камер: {3} градусов"),
+    TR("Referans ekseni başına artık RMS: {0}/{1}/{2} m; oturtulan yukarı ekseni "
+       "kameraların ortalama yukarısına karşı: {3} derece"));
 
 SS_MSG(metric_positions_bad,
     EN("Positions file {0} cannot be read: {1}"),

--- a/src/i18n/catalog/Sfm.h
+++ b/src/i18n/catalog/Sfm.h
@@ -2403,32 +2403,40 @@ SS_MSG(metric_source_positions,
 
 SS_MSG(metric_done,
     EN("Model {0}: metric frame from {1} -- scale {2}, cameras within {3} m: {4}/{5}, "
-       "RMS {6} m, scale uncertainty {7}%, orientation uncertainty {8} deg"),
+       "RMS {6} m; assuming uncorrelated reference error, which is a lower bound, "
+       "scale uncertainty {7}% and orientation uncertainty {8} deg"),
     JA("モデル {0}: {1} によるメートル座標系 -- 縮尺 {2}、{3} m 以内のカメラ: {4}/{5}、"
-       "RMS {6} m、縮尺の不確かさ {7}%、向きの不確かさ {8} 度"),
+       "RMS {6} m。基準の誤差が無相関という下限の仮定で、縮尺の不確かさ {7}%、向きの不確かさ {8} 度"),
     ZH_HANS("模型 {0}: 由{1}确定的米制坐标系 -- 缩放 {2}，{3} m 以内的相机: {4}/{5}，"
-            "RMS {6} m，缩放不确定度 {7}%，朝向不确定度 {8} 度"),
+            "RMS {6} m; 按参考误差互不相关这一下限假设，缩放不确定度 {7}%、朝向不确定度 {8} 度"),
     ZH_HANT("模型 {0}: 由{1}確定的公尺座標系 -- 縮放 {2}，{3} m 以內的相機: {4}/{5}，"
-            "RMS {6} m，縮放不確定度 {7}%，朝向不確定度 {8} 度"),
+            "RMS {6} m; 按參考誤差互不相關這一下限假設，縮放不確定度 {7}%、朝向不確定度 {8} 度"),
     KO("모델 {0}: {1} 기준 미터 좌표계 -- 배율 {2}, {3} m 이내 카메라: {4}/{5}, "
-       "RMS {6} m, 배율 불확실도 {7}%, 방향 불확실도 {8} 도"),
+       "RMS {6} m; 기준 오차가 무상관이라는 하한 가정에서 배율 불확실도 {7}%, 방향 불확실도 {8} 도"),
     DE("Modell {0}: metrischer Rahmen aus {1} -- Maßstab {2}, Kameras innerhalb {3} m: "
-       "{4}/{5}, RMS {6} m, Maßstabsunsicherheit {7}%, Orientierungsunsicherheit {8} Grad"),
+       "{4}/{5}, RMS {6} m; unter der Untergrenzannahme unkorrelierter Referenzfehler "
+       "Maßstabsunsicherheit {7}% und Orientierungsunsicherheit {8} Grad"),
     FR("Modèle {0} : repère métrique d'après {1} -- échelle {2}, caméras à moins de {3} m : "
-       "{4}/{5}, RMS {6} m, incertitude d'échelle {7}%, incertitude d'orientation {8} degrés"),
+       "{4}/{5}, RMS {6} m ; en supposant une erreur de référence non corrélée, ce qui est "
+       "une borne inférieure, incertitude d'échelle {7}% et d'orientation {8} degrés"),
     ES("Modelo {0}: marco métrico a partir de {1} -- escala {2}, cámaras dentro de {3} m: "
-       "{4}/{5}, RMS {6} m, incertidumbre de escala {7}%, incertidumbre de orientación {8} grados"),
+       "{4}/{5}, RMS {6} m; suponiendo error de referencia no correlacionado, que es una cota "
+       "inferior, incertidumbre de escala {7}% y de orientación {8} grados"),
     PT("Modelo {0}: referencial métrico a partir de {1} -- escala {2}, câmeras dentro de {3} m: "
-       "{4}/{5}, RMS {6} m, incerteza de escala {7}%, incerteza de orientação {8} graus"),
+       "{4}/{5}, RMS {6} m; supondo erro de referência não correlacionado, que é um limite "
+       "inferior, incerteza de escala {7}% e de orientação {8} graus"),
     IT("Modello {0}: sistema metrico da {1} -- scala {2}, camere entro {3} m: {4}/{5}, "
-       "RMS {6} m, incertezza di scala {7}%, incertezza di orientamento {8} gradi"),
+       "RMS {6} m; assumendo errore di riferimento non correlato, che è un limite inferiore, "
+       "incertezza di scala {7}% e di orientamento {8} gradi"),
     NL("Model {0}: metrisch stelsel uit {1} -- schaal {2}, camera's binnen {3} m: {4}/{5}, "
-       "RMS {6} m, schaalonzekerheid {7}%, oriëntatieonzekerheid {8} graden"),
+       "RMS {6} m; uitgaande van ongecorreleerde referentiefout, wat een ondergrens is, "
+       "schaalonzekerheid {7}% en oriëntatieonzekerheid {8} graden"),
     RU("Модель {0}: метрическая система по источнику {1} -- масштаб {2}, камер в пределах "
-       "{3} м: {4}/{5}, СКО {6} м, неопределённость масштаба {7}%, неопределённость "
-       "ориентации {8} градусов"),
+       "{3} м: {4}/{5}, СКО {6} м; в предположении некоррелированной ошибки эталона, что даёт "
+       "нижнюю границу, неопределённость масштаба {7}% и ориентации {8} градусов"),
     TR("Model {0}: {1} kaynaklı metrik çerçeve -- ölçek {2}, {3} m içindeki kameralar: "
-       "{4}/{5}, RMS {6} m, ölçek belirsizliği {7}%, yönelim belirsizliği {8} derece"));
+       "{4}/{5}, RMS {6} m; ilişkisiz referans hatası varsayımıyla, ki bu bir alt sınırdır, "
+       "ölçek belirsizliği {7}% ve yönelim belirsizliği {8} derece"));
 
 SS_MSG(metric_failed,
     EN("Model {0}: metric frame NOT applied, written in the normalized frame instead -- {1}"),
@@ -2495,44 +2503,36 @@ SS_MSG(metric_fail_inliers,
     RU("камер в пределах {0} м от подгонки: {1}/{2}, нужна половина"),
     TR("uyuma {0} m içinde olan kamera: {1}/{2}, yarısı gerekli"));
 
-SS_MSG(metric_fail_scale,
-    EN("scale uncertainty {0}% is above {1}%: the positions are too noisy for a capture "
-       "this size"),
-    JA("縮尺の不確かさ {0}% が {1}% を超えています。この規模の撮影には位置の誤差が大きすぎます"),
-    ZH_HANS("缩放不确定度 {0}% 超过 {1}%: 对这个尺度的采集来说位置噪声太大"),
-    ZH_HANT("縮放不確定度 {0}% 超過 {1}%: 對這個尺度的拍攝來說位置雜訊太大"),
-    KO("배율 불확실도 {0}% 가 {1}% 를 넘습니다. 이 규모의 촬영에는 위치 오차가 너무 큽니다"),
-    DE("Maßstabsunsicherheit {0}% liegt über {1}%: die Positionen sind für eine Aufnahme "
-       "dieser Größe zu verrauscht"),
-    FR("l'incertitude d'échelle {0}% dépasse {1}% : les positions sont trop bruitées pour "
-       "une prise de cette taille"),
-    ES("la incertidumbre de escala {0}% supera {1}%: las posiciones tienen demasiado ruido "
-       "para una toma de este tamaño"),
-    PT("a incerteza de escala {0}% ultrapassa {1}%: as posições têm demasiado ruído para "
-       "uma captura deste tamanho"),
-    IT("l'incertezza di scala {0}% supera {1}%: le posizioni sono troppo rumorose per una "
-       "ripresa di queste dimensioni"),
-    NL("schaalonzekerheid {0}% ligt boven {1}%: de posities zijn te ruizig voor een opname "
-       "van deze omvang"),
-    RU("неопределённость масштаба {0}% выше {1}%: позиции слишком шумные для съёмки "
-       "такого размера"),
-    TR("ölçek belirsizliği {0}%, {1}% üzerinde: konumlar bu boyuttaki bir çekim için "
-       "fazla gürültülü"));
-
-SS_MSG(metric_fail_rotation,
-    EN("orientation uncertainty {0} deg is above {1}: the cameras lie along a line"),
-    JA("向きの不確かさ {0} 度が {1} を超えています。カメラが一直線上に並んでいます"),
-    ZH_HANS("朝向不确定度 {0} 度超过 {1}: 相机排成了一条直线"),
-    ZH_HANT("朝向不確定度 {0} 度超過 {1}: 相機排成了一條直線"),
-    KO("방향 불확실도 {0} 도가 {1} 을 넘습니다. 카메라가 일직선에 놓여 있습니다"),
-    DE("Orientierungsunsicherheit {0} Grad liegt über {1}: die Kameras liegen auf einer Linie"),
-    FR("l'incertitude d'orientation {0} degrés dépasse {1} : les caméras sont alignées"),
-    ES("la incertidumbre de orientación {0} grados supera {1}: las cámaras están alineadas"),
-    PT("a incerteza de orientação {0} graus ultrapassa {1}: as câmeras estão alinhadas"),
-    IT("l'incertezza di orientamento {0} gradi supera {1}: le camere sono allineate"),
-    NL("oriëntatieonzekerheid {0} graden ligt boven {1}: de camera's liggen op één lijn"),
-    RU("неопределённость ориентации {0} градусов выше {1}: камеры лежат на одной прямой"),
-    TR("yönelim belirsizliği {0} derece, {1} üzerinde: kameralar tek bir doğru üzerinde"));
+SS_MSG(metric_fail_collinear,
+    EN("the cameras lie too close to a line: the spread across it is {0}% of the whole "
+       "and {1}% is the minimum, so this reference amplifies orientation error {2}x"),
+    JA("カメラがほぼ一直線に並んでいます。直線を横切る広がりは全体の {0}% で、最小は {1}% です。"
+       "この基準では向きの誤差が {2} 倍に拡大します"),
+    ZH_HANS("相机太接近一条直线: 横向展开只占整体的 {0}%，最小需要 {1}%，这样的参考会把朝向误差"
+            "放大 {2} 倍"),
+    ZH_HANT("相機太接近一條直線: 橫向展開只占整體的 {0}%，最小需要 {1}%，這樣的參考會把朝向誤差"
+            "放大 {2} 倍"),
+    KO("카메라가 거의 일직선에 놓여 있습니다. 직선을 가로지르는 퍼짐이 전체의 {0}% 이고 최소는 "
+       "{1}% 입니다. 이런 기준은 방향 오차를 {2} 배로 키웁니다"),
+    DE("die Kameras liegen zu nah an einer Linie: die Streuung quer dazu ist {0}% des Ganzen, "
+       "das Minimum ist {1}%, also verstärkt diese Referenz den Orientierungsfehler um das "
+       "{2}-fache"),
+    FR("les caméras sont trop proches d'une ligne : l'étalement en travers vaut {0}% du total "
+       "et le minimum est {1}%, donc cette référence amplifie l'erreur d'orientation {2} fois"),
+    ES("las cámaras están demasiado cerca de una línea: la dispersión transversal es el {0}% "
+       "del total y el mínimo es {1}%, así que esta referencia amplifica el error de "
+       "orientación {2} veces"),
+    PT("as câmeras estão demasiado perto de uma linha: a dispersão transversal é {0}% do total "
+       "e o mínimo é {1}%, portanto esta referência amplifica o erro de orientação {2} vezes"),
+    IT("le camere sono troppo vicine a una linea: la dispersione trasversale è il {0}% del "
+       "totale e il minimo è {1}%, quindi questo riferimento amplifica l'errore di "
+       "orientamento {2} volte"),
+    NL("de camera's liggen te dicht bij een lijn: de spreiding dwars erop is {0}% van het "
+       "geheel en {1}% is het minimum, dus deze referentie versterkt de oriëntatiefout {2} keer"),
+    RU("камеры лежат слишком близко к прямой: разброс поперёк неё составляет {0}% от общего "
+       "при минимуме {1}%, поэтому такой эталон усиливает ошибку ориентации в {2} раз"),
+    TR("kameralar bir doğruya fazla yakın: enine yayılım bütünün {0}% kadarı ve en az {1}% "
+       "olmalı, yani bu referans yönelim hatasını {2} kat büyütür"));
 
 SS_MSG(metric_matched,
     EN("Positions file: matched {0}/{1} cameras (names not in the model: {2})"),

--- a/src/i18n/catalog/SfmFields.h
+++ b/src/i18n/catalog/SfmFields.h
@@ -3200,6 +3200,102 @@ SS_MSG(quiet_help,
     RU("Печатать только строки результата, без прогресса по стадиям"),
     TR("Yalnızca sonuç satırlarını yazdır, aşama aşama ilerlemeyi değil"));
 
+SS_MSG(metric_positions_help,
+    EN("Write the model in the metric frame of these camera positions (one "
+       "`image_name X Y Z` per line, metres); a failed fit is reported and the model is "
+       "written un-scaled"),
+    JA("この camera 位置ファイル (1 行につき `image_name X Y Z`、メートル) のメートル座標系で"
+       "モデルを書き出します。当てはめに失敗した場合は報告し、縮尺なしで書き出します"),
+    ZH_HANS("按这些相机位置 (每行 `image_name X Y Z`，单位米) 的米制坐标系写出模型; 拟合失败会"
+            "报告，并按未缩放写出"),
+    ZH_HANT("按這些相機位置 (每行 `image_name X Y Z`，單位公尺) 的公尺座標系寫出模型; 擬合失敗"
+            "會回報，並按未縮放寫出"),
+    KO("이 카메라 위치 (한 줄에 `image_name X Y Z`, 미터) 의 미터 좌표계로 모델을 씁니다. "
+       "맞춤에 실패하면 보고하고 배율 없이 씁니다"),
+    DE("Das Modell im metrischen Rahmen dieser Kamerapositionen schreiben (je Zeile "
+       "`image_name X Y Z`, Meter); eine gescheiterte Anpassung wird gemeldet und das "
+       "Modell unskaliert geschrieben"),
+    FR("Écrire le modèle dans le repère métrique de ces positions de caméra (une ligne "
+       "`image_name X Y Z`, en mètres) ; un ajustement raté est signalé et le modèle est "
+       "écrit sans mise à l'échelle"),
+    ES("Escribir el modelo en el marco métrico de estas posiciones de cámara (una línea "
+       "`image_name X Y Z`, en metros); un ajuste fallido se informa y el modelo se "
+       "escribe sin escalar"),
+    PT("Escrever o modelo no referencial métrico destas posições de câmera (uma linha "
+       "`image_name X Y Z`, em metros); um ajuste falhado é relatado e o modelo é escrito "
+       "sem escala"),
+    IT("Scrivere il modello nel sistema metrico di queste posizioni di camera (una riga "
+       "`image_name X Y Z`, in metri); una stima fallita viene segnalata e il modello "
+       "scritto senza scala"),
+    NL("Het model schrijven in het metrische stelsel van deze cameraposities (per regel "
+       "`image_name X Y Z`, meters); een mislukte fit wordt gemeld en het model ongeschaald "
+       "geschreven"),
+    RU("Записать модель в метрической системе этих позиций камер (по строке "
+       "`image_name X Y Z`, метры); неудачная подгонка сообщается, и модель пишется "
+       "без масштабирования"),
+    TR("Modeli bu kamera konumlarının metrik çerçevesinde yaz (satır başına "
+       "`image_name X Y Z`, metre); başarısız uyum bildirilir ve model ölçeklenmeden yazılır"));
+
+SS_MSG(metric_gps_help,
+    EN("Write the model in a local east-north-up metre frame fitted to the images' EXIF "
+       "GPS; accuracy is a few metres, so the capture must be tens of metres across"),
+    JA("画像の EXIF GPS に合わせたローカルな東北上メートル座標系でモデルを書き出します。"
+       "精度は数メートルなので、撮影範囲は数十メートル必要です"),
+    ZH_HANS("按图像 EXIF GPS 拟合的本地东北天米制坐标系写出模型; 精度只有几米，所以采集范围要有"
+            "几十米"),
+    ZH_HANT("按影像 EXIF GPS 擬合的本地東北天公尺座標系寫出模型; 精度只有幾公尺，所以拍攝範圍要"
+            "有數十公尺"),
+    KO("이미지의 EXIF GPS 에 맞춘 지역 동북상 미터 좌표계로 모델을 씁니다. 정확도가 수 미터라 "
+       "촬영 범위가 수십 미터는 되어야 합니다"),
+    DE("Das Modell in einem lokalen Ost-Nord-Oben-Meterrahmen schreiben, der an das EXIF-GPS "
+       "der Bilder angepasst wird; die Genauigkeit liegt bei einigen Metern, die Aufnahme "
+       "muss also zehner Meter groß sein"),
+    FR("Écrire le modèle dans un repère local est-nord-haut en mètres ajusté au GPS EXIF des "
+       "images ; la précision est de quelques mètres, la prise doit donc faire des dizaines "
+       "de mètres"),
+    ES("Escribir el modelo en un marco local este-norte-arriba en metros ajustado al GPS "
+       "EXIF de las imágenes; la precisión es de unos metros, así que la toma debe medir "
+       "decenas de metros"),
+    PT("Escrever o modelo num referencial local este-norte-cima em metros ajustado ao GPS "
+       "EXIF das imagens; a precisão é de alguns metros, por isso a captura tem de ter "
+       "dezenas de metros"),
+    IT("Scrivere il modello in un sistema locale est-nord-alto in metri stimato dal GPS EXIF "
+       "delle immagini; la precisione è di alcuni metri, quindi la ripresa deve misurare "
+       "decine di metri"),
+    NL("Het model schrijven in een lokaal oost-noord-omhoog meterstelsel dat op de EXIF-GPS "
+       "van de beelden is gefit; de nauwkeurigheid is enkele meters, dus de opname moet "
+       "tientallen meters groot zijn"),
+    RU("Записать модель в локальной метровой системе восток-север-верх, подогнанной к GPS из "
+       "EXIF снимков; точность в несколько метров, поэтому съёмка должна быть десятки метров"),
+    TR("Modeli, görüntülerin EXIF GPS'ine oturtulmuş yerel bir doğu-kuzey-yukarı metre "
+       "çerçevesinde yaz; doğruluk birkaç metre olduğundan çekim onlarca metre olmalı"));
+
+SS_MSG(metric_max_error_help,
+    EN("Cameras farther than this many metres from the fitted position are outliers; 0 "
+       "chooses 5 for GPS and 0.5 for a positions file"),
+    JA("当てはめ位置からこのメートル数より離れたカメラを外れ値とします。0 なら GPS で 5、"
+       "位置ファイルで 0.5 を選びます"),
+    ZH_HANS("离拟合位置超过这么多米的相机算作外点; 0 表示 GPS 取 5、位置文件取 0.5"),
+    ZH_HANT("離擬合位置超過這麼多公尺的相機算作外點; 0 表示 GPS 取 5、位置檔取 0.5"),
+    KO("맞춘 위치에서 이 미터 수보다 먼 카메라는 이상치로 봅니다. 0 이면 GPS 는 5, 위치 파일은 "
+       "0.5 를 씁니다"),
+    DE("Kameras weiter als so viele Meter von der angepassten Position sind Ausreißer; 0 "
+       "wählt 5 für GPS und 0,5 für eine Positionsdatei"),
+    FR("Les caméras à plus de tant de mètres de la position ajustée sont aberrantes ; 0 "
+       "choisit 5 pour le GPS et 0,5 pour un fichier de positions"),
+    ES("Las cámaras a más de tantos metros de la posición ajustada son atípicas; 0 elige 5 "
+       "para GPS y 0,5 para un archivo de posiciones"),
+    PT("Câmeras a mais do que estes metros da posição ajustada são atípicas; 0 escolhe 5 "
+       "para GPS e 0,5 para um ficheiro de posições"),
+    IT("Le camere oltre questi metri dalla posizione stimata sono anomale; 0 sceglie 5 per "
+       "il GPS e 0,5 per un file di posizioni"),
+    NL("Camera's verder dan zoveel meter van de gefitte positie zijn uitschieters; 0 kiest 5 "
+       "voor GPS en 0,5 voor een positiebestand"),
+    RU("Камеры дальше такого числа метров от подогнанной позиции считаются выбросами; 0 "
+       "выбирает 5 для GPS и 0,5 для файла позиций"),
+    TR("Oturtulan konumdan bu kadar metreden uzak kameralar aykırıdır; 0, GPS için 5 ve "
+       "konum dosyası için 0,5 seçer"));
+
 }  // namespace sfmfield
 }  // namespace msg
 }  // namespace i18n

--- a/src/i18n/catalog/SfmHelp.h
+++ b/src/i18n/catalog/SfmHelp.h
@@ -1242,6 +1242,21 @@ SS_MSG(exit_3,
 // `spirula sfm ba` -- the solver benchmark
 // ===========================================================================
 
+SS_MSG(exit_4,
+    EN("the model was written, but not in the metric frame that was asked for"),
+    JA("モデルは書き出されましたが、要求されたメートル座標系ではありません"),
+    ZH_HANS("模型已写出，但不是所要求的米制坐标系"),
+    ZH_HANT("模型已寫出，但不是所要求的公尺座標系"),
+    KO("모델은 썼지만 요청한 미터 좌표계는 아닙니다"),
+    DE("das Modell wurde geschrieben, aber nicht im verlangten metrischen Rahmen"),
+    FR("le modèle a été écrit, mais pas dans le repère métrique demandé"),
+    ES("el modelo se escribió, pero no en el marco métrico solicitado"),
+    PT("o modelo foi escrito, mas não no referencial métrico pedido"),
+    IT("il modello è stato scritto, ma non nel sistema metrico richiesto"),
+    NL("het model is geschreven, maar niet in het gevraagde metrische stelsel"),
+    RU("модель записана, но не в запрошенной метрической системе"),
+    TR("model yazıldı, ancak istenen metrik çerçevede değil"));
+
 SS_MSG(ba_desc_1,
     EN("Runs the GPU bundle adjuster directly on a problem in Bundle Adjustment "
        "in the Large format, and reports cost, iterations, time and VRAM. This "

--- a/src/sfm/README.md
+++ b/src/sfm/README.md
@@ -388,6 +388,26 @@ model is written, so the trainer's own normalization comes out as the identity
 tilted with no way left to recover the transform. `map/Orient.h` has the
 algebra and the caveats; `--no-orient` keeps the mapper's raw gauge.
 
+`--metric-positions FILE` and `--metric-gps` fix that same gauge from an
+outside measurement instead, so the model is written **in metres**. The first
+reads per-image camera positions in COLMAP's `model_aligner --ref_images_path`
+format (`image_name X Y Z` per line, any right-handed metric frame — a LiDAR
+trajectory, ARKit, RTK); the second reads each registered image's own EXIF GPS
+and converts it to a local east-north-up frame. Either way a full similarity is
+fitted from the camera centres with LO-RANSAC over the same `estimateSim3` that
+model merging uses, and `--metric-max-error` is its inlier radius in metres (0
+picks 5 for GPS, 0.5 for a positions file).
+
+The fit is refused rather than approximated. Fewer than three positioned
+cameras, reference positions that do not spread wider than the inlier radius,
+under half the cameras inlying, a scale uncertainty over 2 % or an orientation
+uncertainty over 5° each report their own reason with the numbers behind it;
+the model is then still written, in the ordinary orient gauge, and the exit
+status is 4. The uncertainties come from the inlier residuals assuming
+independent isotropic noise, so they are a lower bound: correlated error — GPS
+drift, or the reconstruction's own — is not in them. `map/MetricGauge.h` has
+the algebra (D74).
+
 ### The finishing passes
 
 Reconstruction ends with up to two more global bundle adjustments, on models

--- a/src/sfm/README.md
+++ b/src/sfm/README.md
@@ -398,15 +398,21 @@ fitted from the camera centres with LO-RANSAC over the same `estimateSim3` that
 model merging uses, and `--metric-max-error` is its inlier radius in metres (0
 picks 5 for GPS, 0.5 for a positions file).
 
-The fit is refused rather than approximated. Fewer than three positioned
-cameras, reference positions that do not spread wider than the inlier radius,
-under half the cameras inlying, a scale uncertainty over 2 % or an orientation
-uncertainty over 5° each report their own reason with the numbers behind it;
+The fit is refused rather than approximated, and **what refuses it is geometry,
+not a noise model**. Fewer than three positioned cameras, reference positions
+that do not spread wider than the inlier radius, under half the cameras inlying,
+or cameras lying so close to a line that the reference amplifies orientation
+error more than 20x — each reports its own reason with the numbers behind it;
 the model is then still written, in the ordinary orient gauge, and the exit
-status is 4. The uncertainties come from the inlier residuals assuming
-independent isotropic noise, so they are a lower bound: correlated error — GPS
-drift, or the reconstruction's own — is not in them. `map/MetricGauge.h` has
-the algebra (D74).
+status is 4.
+
+The scale and orientation uncertainties are **reported and never gated on**.
+They come from the inlier residuals assuming uncorrelated noise, and measured
+against a reference whose error is correlated — GPS drift — they under-state
+the real error by 3.9-4.5x: on one flight a 2 % gate on them passed a 3.6 %
+scale error. A gate that passes what it exists to catch is worse than no gate,
+so they are printed as the lower bounds they are. `map/MetricGauge.h` has the
+algebra (D74).
 
 ### The finishing passes
 

--- a/src/sfm/SfmConfig.cpp
+++ b/src/sfm/SfmConfig.cpp
@@ -449,6 +449,18 @@ std::string SfmConfig::finalize(uint32_t cmd) {
                std::to_string(lomaDescriptorDim(matcher)) + "-D descriptors and "
                "--features " + features + " makes " +
                std::to_string(lomaDescriptorDim(features)) + "-D ones";
+    // Two metric references would each claim the gauge, and the fit would be
+    // whichever the code happened to try first.
+    if (!metric_positions.empty() && metric_gps)
+        return "--metric-positions and --metric-gps are two references for one "
+               "gauge; pass one";
+    if (metric_gps && image_dir.empty() && !(cmd & CMD_AUTO))
+        return "--metric-gps reads each image's EXIF, so it needs --images";
+    // GPS is metres-accurate and a positions file is usually centimetres, so
+    // one default cannot serve both; 0 means "the one for this source".
+    if (metric_max_error == 0)
+        metric_max_error = metric_gps ? 5.0 : 0.5;
+
     lightglue.device = device;
     loma.device = loma_match.device = device;
     if (max_image_size <= 0) max_image_size = defaultMaxImageSize(features);

--- a/src/sfm/SfmConfig.h
+++ b/src/sfm/SfmConfig.h
@@ -133,6 +133,11 @@ struct SfmConfig {
     // Write the finished model in an upright, centred, unit-sized frame rather
     // than in whatever gauge the seed pair left it in (map/Orient.h).
     bool orient = true;
+    // Instead: fix the gauge from an outside measurement in metres, so the
+    // model is written metric (map/MetricGauge.h, D74).
+    std::string metric_positions;       // one `image_name X Y Z` per line
+    bool metric_gps = false;            // each image's own EXIF GPS
+    double metric_max_error = 0;        // metres; 0 resolves per source
     bool merge_ba = true;               // merge: bundle-adjust across the seams
     bool in_place = false;              // merge: write back over the input
 
@@ -342,6 +347,12 @@ struct SfmConfig {
       Tier::Advanced, "mapper", 0, 0, "", final_per_image_intrinsics)                              \
     F(orient, "orient", CMD_AUTO | CMD_MAP | CMD_MERGE, Tier::Advanced, "mapper", 0, 0, "",        \
       orient)                                                                                      \
+    F(metric_positions, "metric-positions", CMD_AUTO | CMD_MAP | CMD_MERGE, Tier::Advanced,        \
+      "mapper", 0, 0, "", metric_positions)                                                        \
+    F(metric_gps, "metric-gps", CMD_AUTO | CMD_MAP | CMD_MERGE, Tier::Advanced, "mapper", 0, 0,    \
+      "", metric_gps)                                                                              \
+    F(metric_max_error, "metric-max-error", CMD_AUTO | CMD_MAP | CMD_MERGE, Tier::Advanced,        \
+      "mapper", 0, 1000000, "", metric_max_error)                                                  \
     F(mapper.min_tri_angle_deg, "min-tri-angle", CMD_AUTO | CMD_MAP, Tier::Advanced, "mapper", 0,  \
       90, "", min_tri_angle)                                                                       \
     F(mapper.init_min_tri_angle_deg, "init-min-tri-angle", CMD_AUTO | CMD_MAP, Tier::Advanced,     \
@@ -470,7 +481,7 @@ struct SfmConfig {
     F(merge_ba, "ba", CMD_MERGE, Tier::Advanced, "merge", 0, 0, "", ba)                            \
     F(in_place, "in-place", CMD_MERGE, Tier::Advanced, "merge", 0, 0, "", in_place)                \
     /* ---- inputs ---- */                                                                         \
-    F(image_dir, "images", CMD_MAP, Tier::Advanced, "input", 0, 0, "", images)                     \
+    F(image_dir, "images", CMD_MAP | CMD_MERGE, Tier::Advanced, "input", 0, 0, "", images)         \
     F(feature_dir, "features", CMD_MAP, Tier::Advanced, "input", 0, 0, "", feature_dir)            \
     F(resume, "resume", CMD_MAP, Tier::Advanced, "input", 0, 0, "", resume)                        \
     F(check, "check", CMD_MAP, Tier::Advanced, "input", 0, 0, "", check)                           \

--- a/src/sfm/core/Exif.h
+++ b/src/sfm/core/Exif.h
@@ -50,6 +50,12 @@ struct ExifData {
     double shutter_apex  = std::numeric_limits<double>::quiet_NaN();  // Exif:ShutterSpeedValue
     double aperture_apex = std::numeric_limits<double>::quiet_NaN();  // Exif:ApertureValue
 
+    // GPS, from the separate IFD tag 0x8825 points at. Degrees, signed by the
+    // hemisphere ref; altitude negated when GPSAltitudeRef says below sea level.
+    bool has_gps = false;
+    bool has_alt = false;
+    double lat_deg = 0, lon_deg = 0, alt_m = 0;
+
     bool hasFocal() const { return focal_35mm > 0 || focal_mm > 0; }
 };
 
@@ -114,6 +120,19 @@ inline bool tiffValue(const TiffReader& r, size_t entry, double& out) {
     }
 }
 
+// The first `n` components of a RATIONAL entry. tiffValue reads one, which is
+// all the lens tags need; a DMS coordinate is three.
+inline bool tiffRationals(const TiffReader& r, size_t entry, int n, double* out) {
+    if (r.u16(entry + 2) != 5 || (int)r.u32(entry + 4) < n) return false;
+    const size_t vo = (8u * (unsigned)n <= 4) ? entry + 8 : r.u32(entry + 8);
+    for (int i = 0; i < n; i++) {
+        const uint32_t num = r.u32(vo + 8 * (size_t)i), den = r.u32(vo + 8 * (size_t)i + 4);
+        if (den == 0) return false;
+        out[i] = (double)num / den;
+    }
+    return true;
+}
+
 inline std::string tiffString(const TiffReader& r, size_t entry) {
     uint32_t count = r.u32(entry + 4);
     if (count == 0) return {};
@@ -125,6 +144,38 @@ inline std::string tiffString(const TiffReader& r, size_t entry) {
     // Trailing spaces are common ("NIKON CORPORATION   ").
     while (!s.empty() && (s.back() == ' ' || s.back() == '\t')) s.pop_back();
     return s;
+}
+
+// The GPS IFD, which numbers its own tags 1..31 -- the same numbers IFD0 uses
+// for width, height and compression. It gets its own switch for that reason.
+inline void parseGpsIfd(const TiffReader& r, size_t off, ExifData& out) {
+    if (off + 2 > r.n) return;
+    uint16_t count = r.u16(off);
+    if ((size_t)count * 12 + off + 2 > r.n) count = (uint16_t)((r.n - off - 2) / 12);
+    double lat[3] = {0, 0, 0}, lon[3] = {0, 0, 0}, alt = 0, v = 0;
+    bool has_lat = false, has_lon = false, has_alt = false;
+    char lat_ref = 0, lon_ref = 0;
+    int alt_ref = 0;
+    for (uint16_t i = 0; i < count; i++) {
+        const size_t e = off + 2 + (size_t)i * 12;
+        switch (r.u16(e)) {
+            case 0x0001: { std::string s = tiffString(r, e); if (!s.empty()) lat_ref = s[0]; } break;
+            case 0x0002: has_lat = tiffRationals(r, e, 3, lat); break;
+            case 0x0003: { std::string s = tiffString(r, e); if (!s.empty()) lon_ref = s[0]; } break;
+            case 0x0004: has_lon = tiffRationals(r, e, 3, lon); break;
+            case 0x0005: if (tiffValue(r, e, v)) alt_ref = (int)v; break;
+            case 0x0006: has_alt = tiffRationals(r, e, 1, &alt); break;
+            default: break;
+        }
+    }
+    if (!has_lat || !has_lon || !lat_ref || !lon_ref) return;
+    out.lat_deg = lat[0] + lat[1] / 60.0 + lat[2] / 3600.0;
+    out.lon_deg = lon[0] + lon[1] / 60.0 + lon[2] / 3600.0;
+    if (lat_ref == 'S' || lat_ref == 's') out.lat_deg = -out.lat_deg;
+    if (lon_ref == 'W' || lon_ref == 'w') out.lon_deg = -out.lon_deg;
+    out.has_alt = has_alt;
+    out.alt_m = alt_ref == 1 ? -alt : alt;
+    out.has_gps = true;
 }
 
 // Walk one IFD, filling `out`. `depth` guards against a file whose Exif-IFD
@@ -142,6 +193,9 @@ inline void parseIfd(const TiffReader& r, size_t off, ExifData& out, int depth) 
             case 0x0110: out.model = tiffString(r, e); break;
             case 0x8769:  // Exif sub-IFD, where the lens tags live
                 if (tiffValue(r, e, v) && v > 0) parseIfd(r, (size_t)v, out, depth + 1);
+                break;
+            case 0x8825:  // GPS IFD; a separate walk, not this switch
+                if (tiffValue(r, e, v) && v > 0) parseGpsIfd(r, (size_t)v, out);
                 break;
             case 0x829A: if (tiffValue(r, e, v) && v > 0) out.exposure_time = v; break;
             case 0x829D: if (tiffValue(r, e, v) && v > 0) out.f_number = v; break;

--- a/src/sfm/map/MetricGauge.h
+++ b/src/sfm/map/MetricGauge.h
@@ -23,6 +23,7 @@
 #include "sfm/core/Exif.h"
 #include "sfm/core/Model.h"
 #include "sfm/core/Pose.h"
+#include "sfm/map/Orient.h"
 #include "sfm/geometry/LinAlg.h"
 #include "sfm/optim/Ransac.h"
 #include "sfm/map/Merge.h"
@@ -349,6 +350,15 @@ inline MetricGpsCounts metricRefFromGps(const Reconstruction& rec, const std::st
         ref.image_ids.push_back(ids[i]);
     }
     return c;
+}
+
+
+// Angle between the reference frame's +Z and where the cameras themselves say
+// up is. A few degrees on a hand-held or gimballed capture; tens of degrees
+// means a tilted reference or a tilted capture, and says which to look at.
+inline double metricUpDisagreementDeg(const Reconstruction& rec) {
+    const Sim3 up = uprightTransform(rec);
+    return std::acos(std::max(-1.0, std::min(1.0, up.R[8]))) * 180.0 / M_PI;
 }
 
 }  // namespace sfm

--- a/src/sfm/map/MetricGauge.h
+++ b/src/sfm/map/MetricGauge.h
@@ -1,0 +1,180 @@
+// The metric gauge: a Sim(3) from the model's camera centres onto reference
+// positions in metres, with the uncertainty that says whether to trust it.
+//
+// Where Orient.h fixes the gauge from the poses alone -- upright, centred,
+// unit-sized -- this fixes it from an outside measurement, so the written
+// model is in metres and every consumer inherits that for free (D74).
+//
+// The reported uncertainty assumes independent isotropic noise on the
+// reference positions. Correlated error (GPS drift, SfM drift) is not in it,
+// so it is a LOWER BOUND on the real uncertainty, not an estimate of it.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "sfm/core/Pose.h"
+#include "sfm/geometry/LinAlg.h"
+#include "sfm/optim/Ransac.h"
+#include "sfm/map/Merge.h"
+
+namespace sfm {
+
+// Camera centres in the model's own gauge, paired by index with reference
+// positions in metres. `image_ids` is what the caller needs to report; the fit
+// never reads it.
+struct MetricRef {
+    std::vector<Vec3> centres;
+    std::vector<Vec3> targets;
+    std::vector<uint32_t> image_ids;
+};
+
+enum class MetricFail { None, Pairs, Spread, Inliers, Scale, Rotation };
+
+struct MetricFit {
+    bool ok = false;
+    MetricFail reason = MetricFail::Pairs;
+    Sim3 T;
+    int n = 0;                  // paired cameras offered
+    int inliers = 0;
+    double max_error = 0;       // metres
+    double rms = 0;             // metres, over the inliers
+    double scale_unc = 0;       // per cent, std(ds/s)
+    double rot_unc_deg = 0;     // worst principal axis
+    double spread = 0;          // metres, RMS radius of the reference positions
+    std::vector<char> inlier_mask;
+};
+
+inline constexpr double kMetricMaxScaleUncPct = 2.0;
+inline constexpr double kMetricMaxRotUncDeg = 5.0;
+
+namespace detail {
+
+inline Vec3 meanOf(const std::vector<Vec3>& v) {
+    Vec3 m{0, 0, 0};
+    for (const Vec3& p : v) m = m + p;
+    return v.empty() ? m : m * (1.0 / (double)v.size());
+}
+
+}  // namespace detail
+
+// The similarity taking `ref.centres` onto `ref.targets`, refused with a named
+// reason when the data cannot support one. `max_error` is the RANSAC inlier
+// radius in metres.
+inline MetricFit fitMetricGauge(const MetricRef& ref, double max_error) {
+    MetricFit out;
+    out.max_error = max_error;
+    const int n = (int)ref.centres.size();
+    out.n = n;
+    if (n < 3 || (int)ref.targets.size() != n) {
+        out.reason = MetricFail::Pairs;
+        return out;
+    }
+
+    // Reference positions that do not spread out carry no scale to fit, and
+    // every fit to them is an arbitrary one that would pass an RMS gate.
+    const Vec3 pbar = detail::meanOf(ref.targets);
+    double var_t = 0;
+    for (const Vec3& p : ref.targets) var_t += (p - pbar).dot(p - pbar);
+    out.spread = std::sqrt(var_t / (double)n);
+    if (!(out.spread > max_error)) {
+        out.reason = MetricFail::Spread;
+        return out;
+    }
+
+    auto fit_fn = [&](const std::vector<int>& idx) {
+        std::vector<Sim3> models;
+        std::vector<Vec3> s, d;
+        s.reserve(idx.size());
+        d.reserve(idx.size());
+        for (int i : idx) {
+            s.push_back(ref.centres[i]);
+            d.push_back(ref.targets[i]);
+        }
+        Sim3 T;
+        if (estimateSim3(s, d, T)) models.push_back(T);
+        return models;
+    };
+    auto res_fn = [&](const Sim3& T, int i) {
+        const Vec3 r = ref.targets[i] - transformPoint(T, ref.centres[i]);
+        return r.dot(r);
+    };
+
+    RansacOptions opt;
+    opt.max_error = max_error;
+    opt.max_num_trials = 1000;
+    opt.seed = 0;
+    RansacReport<Sim3> rep = loransac<Sim3>(n, 3, fit_fn, fit_fn, res_fn, opt);
+    out.inlier_mask = rep.inlier_mask;
+    out.inliers = std::max(rep.num_inliers, 0);
+    const int need = std::max(3, (n + 1) / 2);
+    if (!rep.success || out.inliers < need) {
+        out.reason = MetricFail::Inliers;
+        return out;
+    }
+
+    std::vector<int> keep;
+    keep.reserve(out.inliers);
+    for (int i = 0; i < n; i++)
+        if (out.inlier_mask[i]) keep.push_back(i);
+    std::vector<Sim3> refit = fit_fn(keep);
+    if (refit.empty()) {
+        out.reason = MetricFail::Inliers;
+        return out;
+    }
+    out.T = refit.front();
+
+    const int m = (int)keep.size();
+    double ss = 0;
+    Vec3 cbar{0, 0, 0};
+    for (int i : keep) {
+        ss += res_fn(out.T, i);
+        cbar = cbar + ref.centres[i];
+    }
+    cbar = cbar * (1.0 / (double)m);
+    out.rms = std::sqrt(ss / (double)m);
+    // Seven parameters come out of 3m residual components, so the noise
+    // estimate divides by what is left.
+    const double sigma = std::sqrt(ss / (double)(3 * m - 7));
+
+    std::vector<double> C(9, 0.0);
+    for (int i : keep) {
+        const Vec3 a = ref.centres[i] - cbar;
+        const double v[3] = {a.x, a.y, a.z};
+        for (int r = 0; r < 3; r++)
+            for (int c = 0; c < 3; c++) C[3 * r + c] += v[r] * v[c];
+    }
+    const double s2 = out.T.scale * out.T.scale;
+    for (double& v : C) v *= s2 / (double)m;
+    std::vector<double> lam, V;
+    jacobiEigenSymmetric(C, 3, lam, V);
+    const double tr = lam[0] + lam[1] + lam[2];
+
+    out.scale_unc = 100.0 * sigma / (std::sqrt((double)m) * std::sqrt(tr));
+    // Rotation about principal axis k is resisted only by the spread
+    // perpendicular to it; where there is none the angle is unidentifiable
+    // whatever the residual says.
+    double worst = 0;
+    for (int k = 0; k < 3; k++) {
+        const double perp = tr - lam[k];
+        worst = std::max(worst, perp > 0.0 ? sigma / std::sqrt((double)m * perp)
+                                           : std::numeric_limits<double>::infinity());
+    }
+    out.rot_unc_deg = worst * 180.0 / M_PI;
+
+    if (!(out.scale_unc <= kMetricMaxScaleUncPct)) {
+        out.reason = MetricFail::Scale;
+        return out;
+    }
+    if (!(out.rot_unc_deg <= kMetricMaxRotUncDeg)) {
+        out.reason = MetricFail::Rotation;
+        return out;
+    }
+    out.ok = true;
+    out.reason = MetricFail::None;
+    return out;
+}
+
+}  // namespace sfm

--- a/src/sfm/map/MetricGauge.h
+++ b/src/sfm/map/MetricGauge.h
@@ -12,6 +12,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -19,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "sfm/core/Exif.h"
 #include "sfm/core/Model.h"
 #include "sfm/core/Pose.h"
 #include "sfm/geometry/LinAlg.h"
@@ -254,6 +256,98 @@ inline MetricPairCounts pairMetricRef(const Reconstruction& rec,
     }
     for (char u : used)
         if (!u) c.unmatched_file++;
+    return c;
+}
+
+
+struct Geodetic {
+    double lat_deg = 0, lon_deg = 0, alt_m = 0;
+};
+
+// WGS-84 geodetic to earth-centred earth-fixed, in double: ECEF magnitudes are
+// ~6.4e6 m, where a float's half-ulp is 0.25 m.
+inline Vec3 ecefFromGeodetic(double lat_deg, double lon_deg, double h) {
+    constexpr double a = 6378137.0, f = 1.0 / 298.257223563;
+    constexpr double e2 = f * (2.0 - f);
+    const double p = lat_deg * M_PI / 180.0, l = lon_deg * M_PI / 180.0;
+    const double sp = std::sin(p), cp = std::cos(p);
+    const double N = a / std::sqrt(1.0 - e2 * sp * sp);
+    return {(N + h) * cp * std::cos(l), (N + h) * cp * std::sin(l), (N * (1.0 - e2) + h) * sp};
+}
+
+// A local east-north-up metre frame about `origin`. Right-handed, north
+// positive. Not valid across the antimeridian or over ~100 km.
+inline std::vector<Vec3> enuFromGeodetic(const std::vector<Geodetic>& g,
+                                         const Geodetic& origin) {
+    std::vector<Vec3> out;
+    if (g.empty()) return out;
+    const double lat0 = origin.lat_deg, lon0 = origin.lon_deg, h0 = origin.alt_m;
+    const Vec3 o = ecefFromGeodetic(lat0, lon0, h0);
+    const double p = lat0 * M_PI / 180.0, l = lon0 * M_PI / 180.0;
+    const double sp = std::sin(p), cp = std::cos(p), sl = std::sin(l), cl = std::cos(l);
+    out.reserve(g.size());
+    for (const Geodetic& q : g) {
+        const Vec3 d = ecefFromGeodetic(q.lat_deg, q.lon_deg, q.alt_m) - o;
+        out.push_back({-sl * d.x + cl * d.y,
+                       -sp * cl * d.x - sp * sl * d.y + cp * d.z,
+                       cp * cl * d.x + cp * sl * d.y + sp * d.z});
+    }
+    return out;
+}
+
+// The same, about the mean of the fixes. The rotation depends on where the
+// origin is, so two origins do not differ by a translation alone.
+inline std::vector<Vec3> enuFromGeodetic(const std::vector<Geodetic>& g) {
+    if (g.empty()) return {};
+    Geodetic o;
+    for (const Geodetic& q : g) {
+        o.lat_deg += q.lat_deg;
+        o.lon_deg += q.lon_deg;
+        o.alt_m += q.alt_m;
+    }
+    const double inv = 1.0 / (double)g.size();
+    o.lat_deg *= inv;
+    o.lon_deg *= inv;
+    o.alt_m *= inv;
+    return enuFromGeodetic(g, o);
+}
+
+
+// What reading GPS off the images found.
+struct MetricGpsCounts {
+    int matched = 0;
+    int no_gps = 0;
+    int no_alt = 0;   // positioned, but with no altitude: treated as sea level
+};
+
+// Reference positions from each registered image's own EXIF, in a local ENU
+// metre frame. Altitude is optional; a fix without one is still a fix.
+inline MetricGpsCounts metricRefFromGps(const Reconstruction& rec, const std::string& image_dir,
+                                        MetricRef& ref) {
+    MetricGpsCounts c;
+    std::vector<Geodetic> g;
+    std::vector<Vec3> centres;
+    std::vector<uint32_t> ids;
+    for (const auto& kv : rec.images) {
+        if (!kv.second.registered) continue;
+        const ExifData e =
+            readExif((std::filesystem::path(image_dir) / kv.second.name).string());
+        if (!e.has_gps) {
+            c.no_gps++;
+            continue;
+        }
+        if (!e.has_alt) c.no_alt++;
+        g.push_back({e.lat_deg, e.lon_deg, e.alt_m});
+        centres.push_back(cameraCenter(kv.second.pose));
+        ids.push_back(kv.first);
+        c.matched++;
+    }
+    std::vector<Vec3> enu = enuFromGeodetic(g);
+    for (size_t i = 0; i < enu.size(); i++) {
+        ref.centres.push_back(centres[i]);
+        ref.targets.push_back(enu[i]);
+        ref.image_ids.push_back(ids[i]);
+    }
     return c;
 }
 

--- a/src/sfm/map/MetricGauge.h
+++ b/src/sfm/map/MetricGauge.h
@@ -58,8 +58,8 @@ struct MetricFit {
 };
 
 // Orientation error grows as 1/perp_frac against scale error, so 0.05 refuses
-// a reference whose shape amplifies it more than 20x. Two real flight segments
-// measure 1.4x and 1.9x; a straight leg and a near-straight one, 80x and 33x.
+// a reference amplifying it beyond 20x -- a starting heuristic, not a bound:
+// the derivation gives the shape, not 20 rather than 10 (D74, one flight).
 inline constexpr double kMetricMinPerpFraction = 0.05;
 
 namespace detail {

--- a/src/sfm/map/MetricGauge.h
+++ b/src/sfm/map/MetricGauge.h
@@ -12,9 +12,14 @@
 
 #include <cmath>
 #include <cstdint>
+#include <fstream>
 #include <limits>
+#include <map>
+#include <sstream>
+#include <string>
 #include <vector>
 
+#include "sfm/core/Model.h"
 #include "sfm/core/Pose.h"
 #include "sfm/geometry/LinAlg.h"
 #include "sfm/optim/Ransac.h"
@@ -175,6 +180,81 @@ inline MetricFit fitMetricGauge(const MetricRef& ref, double max_error) {
     out.ok = true;
     out.reason = MetricFail::None;
     return out;
+}
+
+// What pairing found, so a run can say why it has fewer cameras than either
+// side offered.
+struct MetricPairCounts {
+    int matched = 0;
+    int unmatched_file = 0;    // positions naming no registered image
+    int unmatched_model = 0;   // registered images with no position
+};
+
+// COLMAP's model_aligner --ref_images_path format: `image_name X Y Z` per
+// line, metres, '#' comments, blank lines skipped. `err` names the line.
+inline bool readMetricPositions(const std::string& path, std::map<std::string, Vec3>& out,
+                                std::string& err) {
+    std::ifstream f(path);
+    if (!f) {
+        err = "cannot open " + path;
+        return false;
+    }
+    out.clear();
+    std::string line;
+    for (int lineno = 1; std::getline(f, line); lineno++) {
+        const size_t hash = line.find('#');
+        if (hash != std::string::npos) line.resize(hash);
+        std::istringstream is(line);
+        std::string name;
+        if (!(is >> name)) continue;
+        double x, y, z;
+        std::string extra;
+        if (!(is >> x >> y >> z) || (is >> extra)) {
+            err = "line " + std::to_string(lineno) + ": expected `image_name X Y Z`";
+            return false;
+        }
+        if (!out.emplace(name, Vec3{x, y, z}).second) {
+            err = "line " + std::to_string(lineno) + ": " + name + " appears twice";
+            return false;
+        }
+    }
+    if (out.empty()) {
+        err = "no positions in " + path;
+        return false;
+    }
+    return true;
+}
+
+// Pair registered images to positions on the name the model carries, then on
+// that name without its extension. Never on the basename: two folders holding
+// one file name is a rig capture, not a duplicate.
+inline MetricPairCounts pairMetricRef(const Reconstruction& rec,
+                                      const std::map<std::string, Vec3>& positions,
+                                      MetricRef& ref) {
+    MetricPairCounts c;
+    std::vector<char> used(positions.size(), 0);
+    for (const auto& kv : rec.images) {
+        if (!kv.second.registered) continue;
+        auto it = positions.find(kv.second.name);
+        if (it == positions.end()) {
+            const size_t dot = kv.second.name.find_last_of('.');
+            const size_t slash = kv.second.name.find_last_of('/');
+            if (dot != std::string::npos && (slash == std::string::npos || dot > slash))
+                it = positions.find(kv.second.name.substr(0, dot));
+        }
+        if (it == positions.end()) {
+            c.unmatched_model++;
+            continue;
+        }
+        used[(size_t)std::distance(positions.begin(), it)] = 1;
+        ref.centres.push_back(cameraCenter(kv.second.pose));
+        ref.targets.push_back(it->second);
+        ref.image_ids.push_back(kv.first);
+        c.matched++;
+    }
+    for (char u : used)
+        if (!u) c.unmatched_file++;
+    return c;
 }
 
 }  // namespace sfm

--- a/src/sfm/map/MetricGauge.h
+++ b/src/sfm/map/MetricGauge.h
@@ -5,9 +5,10 @@
 // unit-sized -- this fixes it from an outside measurement, so the written
 // model is in metres and every consumer inherits that for free (D74).
 //
-// The reported uncertainty assumes independent isotropic noise on the
-// reference positions. Correlated error (GPS drift, SfM drift) is not in it,
-// so it is a LOWER BOUND on the real uncertainty, not an estimate of it.
+// The scale and orientation uncertainties are REPORTED, never gated on: they
+// assume uncorrelated noise, and measured against a reference whose error is
+// correlated they under-state it by 3.9-4.5x (D74). What gates is geometry --
+// how far the reference positions spread, and how close to a line they lie.
 #pragma once
 
 #include <cmath>
@@ -39,7 +40,7 @@ struct MetricRef {
     std::vector<uint32_t> image_ids;
 };
 
-enum class MetricFail { None, Pairs, Spread, Inliers, Scale, Rotation };
+enum class MetricFail { None, Pairs, Spread, Inliers, Collinear };
 
 struct MetricFit {
     bool ok = false;
@@ -49,14 +50,17 @@ struct MetricFit {
     int inliers = 0;
     double max_error = 0;       // metres
     double rms = 0;             // metres, over the inliers
-    double scale_unc = 0;       // per cent, std(ds/s)
-    double rot_unc_deg = 0;     // worst principal axis
+    double scale_unc = 0;       // per cent, std(ds/s) -- advisory
+    double rot_unc_deg = 0;     // worst principal axis -- advisory
     double spread = 0;          // metres, RMS radius of the reference positions
+    double perp_frac = 0;       // RMS spread across the long axis, over the whole
     std::vector<char> inlier_mask;
 };
 
-inline constexpr double kMetricMaxScaleUncPct = 2.0;
-inline constexpr double kMetricMaxRotUncDeg = 5.0;
+// Orientation error grows as 1/perp_frac against scale error, so 0.05 refuses
+// a reference whose shape amplifies it more than 20x. Two real flight segments
+// measure 1.4x and 1.9x; a straight leg and a near-straight one, 80x and 33x.
+inline constexpr double kMetricMinPerpFraction = 0.05;
 
 namespace detail {
 
@@ -164,20 +168,18 @@ inline MetricFit fitMetricGauge(const MetricRef& ref, double max_error) {
     // Rotation about principal axis k is resisted only by the spread
     // perpendicular to it; where there is none the angle is unidentifiable
     // whatever the residual says.
-    double worst = 0;
+    double worst = 0, perp_min = 0;
     for (int k = 0; k < 3; k++) {
         const double perp = tr - lam[k];
         worst = std::max(worst, perp > 0.0 ? sigma / std::sqrt((double)m * perp)
                                            : std::numeric_limits<double>::infinity());
+        if (k == 0 || perp < perp_min) perp_min = perp;
     }
     out.rot_unc_deg = worst * 180.0 / M_PI;
+    out.perp_frac = tr > 0.0 ? std::sqrt(std::max(perp_min, 0.0) / tr) : 0.0;
 
-    if (!(out.scale_unc <= kMetricMaxScaleUncPct)) {
-        out.reason = MetricFail::Scale;
-        return out;
-    }
-    if (!(out.rot_unc_deg <= kMetricMaxRotUncDeg)) {
-        out.reason = MetricFail::Rotation;
+    if (!(out.perp_frac >= kMetricMinPerpFraction)) {
+        out.reason = MetricFail::Collinear;
         return out;
     }
     out.ok = true;

--- a/src/sfm/tests/sfm_metric_test.cpp
+++ b/src/sfm/tests/sfm_metric_test.cpp
@@ -1,0 +1,430 @@
+// The metric gauge: Sim(3) fit to reference camera positions, its uncertainty
+// and its gates (host only).
+//
+// Prints PASS/FAIL and returns 0/1. See docs/testing.md.
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include "sfm/core/Camera.h"
+#include "sfm/core/Model.h"
+#include "sfm/map/Orient.h"
+#include "sfm/core/Pose.h"
+#include "sfm/map/MetricGauge.h"
+#include "sfm/tests/TestMain.h"
+
+using namespace sfm;
+
+// Camera at C looking at `target`, y-up. Also in sfm_merge_test.cpp: a local
+// copy beats a shared test-support header for nine lines of scene setup.
+static Pose lookAt(const Vec3& C, const Vec3& target) {
+    Vec3 f = (target - C).normalized();
+    Vec3 up0 = {0, 1, 0};
+    Vec3 r = up0.cross(f).normalized();
+    Vec3 u = f.cross(r);
+    Mat3 R = {r.x, r.y, r.z, u.x, u.y, u.z, f.x, f.y, f.z};
+    Vec3 t = mul(R, C);
+    return {R, {-t.x, -t.y, -t.z}};
+}
+
+// Cameras on an arc of radius 3 with height variation, so the centres span all
+// three axes: a planar or collinear set is a separate fixture below.
+static std::vector<Vec3> arcCentres(int n) {
+    std::vector<Vec3> c(n);
+    for (int i = 0; i < n; i++) {
+        const double a = 2.4 * M_PI * i / n;
+        c[i] = {3.0 * std::cos(a), 0.8 * std::sin(3.0 * a), 3.0 * std::sin(a)};
+    }
+    return c;
+}
+
+static double chordal(const Mat3& A, const Mat3& B) {
+    double s = 0;
+    for (int i = 0; i < 9; i++) s += (A[i] - B[i]) * (A[i] - B[i]);
+    return std::sqrt(s);
+}
+
+static Mat3 rotFromAxisAngle(const Vec3& axis, double ang) {
+    return angleAxisToRotation(axis.normalized() * ang);
+}
+
+// The reference positions a known Sim3 would produce from `centres`.
+static MetricRef makeRef(const std::vector<Vec3>& centres, const Sim3& T) {
+    MetricRef ref;
+    ref.centres = centres;
+    ref.targets.reserve(centres.size());
+    for (const Vec3& c : centres) ref.targets.push_back(transformPoint(T, c));
+    return ref;
+}
+
+int cmdMetricSelftest(int, char**) {
+    int fails = 0;
+    auto check = [&](bool ok, const char* what) {
+        if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+        return ok;
+    };
+
+    // ---- T1: exact recovery of a known Sim3, at two non-unit scales -------
+    // The scales are deliberately not 1: a fit that normalizes by the target
+    // variance, or divides the trace by three, is invisible at s = 1.
+    for (double s_true : {0.0731, 12.4}) {
+        Sim3 T;
+        T.scale = s_true;
+        T.R = rotFromAxisAngle({0.3, -0.7, 0.5}, 0.9);
+        T.t = {11.0, -4.0, 2.5};
+        MetricRef ref = makeRef(arcCentres(24), T);
+        MetricFit fit = fitMetricGauge(ref, 0.05);
+        char what[96];
+        snprintf(what, sizeof what, "T1 s=%g: ok", s_true);
+        check(fit.ok, what);
+        snprintf(what, sizeof what, "T1 s=%g: scale", s_true);
+        check(std::fabs(fit.T.scale / s_true - 1.0) <= 1e-9, what);
+        snprintf(what, sizeof what, "T1 s=%g: rotation", s_true);
+        check(chordal(fit.T.R, T.R) <= 1e-9, what);
+        snprintf(what, sizeof what, "T1 s=%g: rms", s_true);
+        check(fit.rms <= 1e-9, what);
+        snprintf(what, sizeof what, "T1 s=%g: all inliers", s_true);
+        check(fit.inliers == fit.n && fit.n == 24, what);
+    }
+
+    // ---- T1b: a left-handed reference, where the guard actually fires -----
+    // Unguarded this fits to 3e-15 m with det(R) = -1, so no RMS gate can see
+    // it. A coplanar fixture cannot test this: det(cov) is then round-off.
+    {
+        int proper = 0, fitted = 0;
+        double worst_rms = 0;
+        for (int trial = 0; trial < 200; trial++) {
+            std::vector<Vec3> src(24);
+            for (int i = 0; i < 24; i++) {
+                const double a = 2.4 * M_PI * i / 24;
+                src[i] = {3.0 * std::cos(a), 0.02 * std::sin(3.0 * a), 3.0 * std::sin(a)};
+            }
+            Sim3 T;
+            T.scale = 2.5;
+            T.R = rotFromAxisAngle({0.3, -0.7, 0.5}, 0.9 + 0.005 * trial);
+            T.t = {4.0, 1.0, -2.0};
+            MetricRef ref;
+            ref.centres = src;
+            for (const Vec3& c : src)
+                ref.targets.push_back(transformPoint(T, {c.x, -c.y, c.z}));
+            MetricFit fit = fitMetricGauge(ref, 0.5);
+            if (fit.ok) {
+                fitted++;
+                worst_rms = std::max(worst_rms, fit.rms);
+                if (det3(fit.T.R) > 0.999999 && det3(fit.T.R) < 1.000001) proper++;
+            }
+        }
+        printf("  T1b: fitted %d/200, worst rms %.4f m\n", fitted, worst_rms);
+        check(fitted == 200, "T1b mirrored reference: every trial fitted");
+        check(proper == 200, "T1b mirrored reference: det(R) = +1 on 200/200");
+    }
+
+    // ---- T2: gross outliers, and near-threshold points that must survive --
+    {
+        Sim3 T;
+        T.scale = 12.4;
+        T.R = rotFromAxisAngle({0.2, 0.4, -0.9}, 1.7);
+        T.t = {-3.0, 8.0, 1.0};
+        // Above 3 m, so that comparing an unsquared residual to max_error^2
+        // LOOSENS the threshold: 3x is then rejected but 3x < max_err^2, and
+        // 3x > 2x means no shift of the model can capture it either.
+        const double max_err = 4.0;
+        std::vector<Vec3> centres = arcCentres(40);
+        MetricRef ref = makeRef(centres, T);
+        std::vector<char> want(40, 1);
+        std::mt19937 rng(5);
+        std::uniform_real_distribution<double> dir(-1.0, 1.0);
+        for (int i = 0; i < 40; i++) {
+            Vec3 d = Vec3{dir(rng), dir(rng), dir(rng)}.normalized();
+            if (i % 10 == 3 || i % 10 == 7) {         // 20 %: out at 3x
+                ref.targets[i] = ref.targets[i] + d * (3.0 * max_err);
+                want[i] = 0;
+            } else if (i % 10 == 5) {                 // 10 %: in at 0.3x
+                ref.targets[i] = ref.targets[i] + d * (0.3 * max_err);
+            }
+        }
+        MetricFit fit = fitMetricGauge(ref, max_err);
+        check(fit.ok, "T2: ok");
+        bool mask_exact = fit.inlier_mask.size() == want.size();
+        for (size_t i = 0; mask_exact && i < want.size(); i++)
+            mask_exact = (fit.inlier_mask[i] != 0) == (want[i] != 0);
+        check(mask_exact, "T2: inlier mask equals the constructed set exactly");
+        check(fit.inliers == 32, "T2: 32 inliers");
+        {
+            int wrong_in = 0, wrong_out = 0;
+            for (size_t i = 0; i < want.size(); i++) {
+                if (want[i] && !fit.inlier_mask[i]) wrong_out++;
+                if (!want[i] && fit.inlier_mask[i]) wrong_in++;
+            }
+            printf("  T2: inliers %d (want 32), kept-outliers %d, dropped-inliers %d\n",
+                   fit.inliers, wrong_in, wrong_out);
+        }
+        // The kept near-threshold points carry real displacement, so the refit
+        // moves off truth by a bounded amount rather than to 1e-9.
+        printf("  T2: scale rel err %.3e\n", std::fabs(fit.T.scale / T.scale - 1.0));
+        check(std::fabs(fit.T.scale / T.scale - 1.0) <= 5e-3, "T2: scale within 0.5 %");
+    }
+
+    // ---- T3: 300 trials of one geometry with fresh noise ------------------
+    // Empirical spread of the recovered scale, and of the rotation about the
+    // WORST principal axis, against what the fit predicts for each.
+    {
+        const int trials = 300, n = 50;
+        const double sigma = 0.05, s_true = 0.7;
+        Sim3 T;
+        T.scale = s_true;
+        T.R = rotFromAxisAngle({0.5, 0.2, 0.84}, 0.6);
+        T.t = {2.0, -1.0, 0.5};
+        std::vector<Vec3> centres = arcCentres(n);
+        // The axis the reported figure is the worst of: least spread across it,
+        // so the largest eigenvalue of the centres' covariance.
+        Vec3 cbar{0, 0, 0};
+        for (const Vec3& c : centres) cbar = cbar + c;
+        cbar = cbar * (1.0 / n);
+        std::vector<double> C(9, 0.0), lam, V;
+        for (const Vec3& c : centres) {
+            const Vec3 a = c - cbar;
+            const double v[3] = {a.x, a.y, a.z};
+            for (int r = 0; r < 3; r++)
+                for (int q = 0; q < 3; q++) C[3 * r + q] += v[r] * v[q] / n;
+        }
+        jacobiEigenSymmetric(C, 3, lam, V);
+        int kmax = 0;
+        for (int k = 1; k < 3; k++)
+            if (lam[k] > lam[kmax]) kmax = k;
+        const Vec3 axis = mul(T.R, Vec3{V[kmax], V[3 + kmax], V[6 + kmax]});
+
+        std::mt19937 rng(3);
+        std::normal_distribution<double> nz(0.0, sigma);
+        double sum_rel = 0, sum_rel2 = 0, sum_ax2 = 0;
+        double pred_scale = 0, pred_rot = 0;
+        int ok_count = 0;
+        for (int k = 0; k < trials; k++) {
+            MetricRef ref = makeRef(centres, T);
+            for (Vec3& p : ref.targets) p = p + Vec3{nz(rng), nz(rng), nz(rng)};
+            MetricFit fit = fitMetricGauge(ref, 1.0);   // 11 sigma: nothing is rejected
+            if (!fit.ok) continue;
+            ok_count++;
+            const double rel = fit.T.scale / s_true - 1.0;
+            sum_rel += rel;
+            sum_rel2 += rel * rel;
+            const Vec3 dth = rotationToAngleAxis(mul(fit.T.R, transpose(T.R)));
+            const double about = dth.dot(axis);
+            sum_ax2 += about * about;
+            pred_scale += fit.scale_unc / 100.0;
+            pred_rot += fit.rot_unc_deg * M_PI / 180.0;
+        }
+        check(ok_count == trials, "T3: every trial fitted");
+        const double emp_scale =
+            std::sqrt(sum_rel2 / ok_count - (sum_rel / ok_count) * (sum_rel / ok_count));
+        const double emp_rot = std::sqrt(sum_ax2 / ok_count);
+        pred_scale /= ok_count;
+        pred_rot /= ok_count;
+        const double r_s = emp_scale / pred_scale, r_r = emp_rot / pred_rot;
+        printf("  T3: scale emp/pred = %.4f (emp %.3e pred %.3e), "
+               "rot emp/pred = %.4f (emp %.3e pred %.3e rad)\n",
+               r_s, emp_scale, pred_scale, r_r, emp_rot, pred_rot);
+        check(r_s >= 0.75 && r_s <= 1.33, "T3: scale uncertainty predicts the spread");
+        check(r_r >= 0.75 && r_r <= 1.33, "T3: rotation uncertainty predicts the spread");
+    }
+
+    // ---- T4: every refusal, asserted on its REASON, not on the bool ------
+    {
+        Sim3 T;
+        T.scale = 4.0;
+        T.R = mat3Identity();
+        T.t = {0, 0, 0};
+        for (int n : {0, 1, 2}) {
+            MetricRef ref = makeRef(arcCentres(std::max(n, 1)), T);
+            ref.centres.resize(n);
+            ref.targets.resize(n);
+            MetricFit fit = fitMetricGauge(ref, 0.5);
+            check(!fit.ok && fit.reason == MetricFail::Pairs, "T4: n < 3 -> Pairs");
+        }
+        {   // every reference position identical: nothing to fit a scale to
+            MetricRef ref = makeRef(arcCentres(20), T);
+            for (Vec3& p : ref.targets) p = ref.targets[0];
+            MetricFit fit = fitMetricGauge(ref, 0.5);
+            check(!fit.ok && fit.reason == MetricFail::Spread, "T4: no spread -> Spread");
+        }
+        {   // cameras exactly on a line: the rotation about it is free
+            MetricRef ref;
+            for (int i = 0; i < 20; i++) {
+                ref.centres.push_back({0.4 * i, 0, 0});
+                ref.targets.push_back({1.6 * i, 0, 0});
+            }
+            MetricFit fit = fitMetricGauge(ref, 0.5);
+            check(!fit.ok && fit.reason == MetricFail::Rotation, "T4: collinear -> Rotation");
+        }
+        {   // every reference position wrong by far more than max_error
+            MetricRef ref = makeRef(arcCentres(20), T);
+            std::mt19937 rng(9);
+            std::uniform_real_distribution<double> big(-500.0, 500.0);
+            for (Vec3& p : ref.targets) p = {big(rng), big(rng), big(rng)};
+            MetricFit fit = fitMetricGauge(ref, 0.05);
+            check(!fit.ok && fit.reason == MetricFail::Inliers, "T4: all outliers -> Inliers");
+            check(fit.inliers < (fit.n + 1) / 2, "T4: all outliers -> under half are inliers");
+        }
+        {   // A minority that agrees perfectly is still a minority: 8 of 24
+            // cameras on an exact Sim3, the rest elsewhere. The 8 are well
+            // spread, so every uncertainty gate would wave them through.
+            Sim3 T2;
+            T2.scale = 2.0;
+            T2.R = rotFromAxisAngle({0.1, 0.2, 0.97}, 1.3);
+            T2.t = {6.0, -2.0, 3.0};
+            MetricRef ref = makeRef(arcCentres(24), T2);
+            std::mt19937 rng(31);
+            std::uniform_real_distribution<double> big(-300.0, 300.0);
+            for (int i = 8; i < 24; i++) ref.targets[i] = {big(rng), big(rng), big(rng)};
+            MetricFit fit = fitMetricGauge(ref, 0.2);
+            printf("  T4: minority consensus %d/%d, scale unc %.4f %%, rot unc %.4f deg\n",
+                   fit.inliers, fit.n, fit.scale_unc, fit.rot_unc_deg);
+            check(fit.inliers == 8, "T4: the minority consensus is found");
+            check(!fit.ok && fit.reason == MetricFail::Inliers,
+                  "T4: a well-conditioned minority is still refused");
+        }
+    }
+
+    // ---- T8: applySim3 puts the centres on the targets, and moves nothing
+    // else. Reprojection is gauge-invariant, so it must not budge.
+    {
+        Sim3 T;
+        T.scale = 0.0731;
+        T.R = rotFromAxisAngle({0.6, -0.3, 0.74}, 1.1);
+        T.t = {40.0, -12.0, 7.0};
+        const int M = 18, N = 200;
+        const int W = 1280, H = 960;
+        Camera K = Camera::defaultFor(1, W, H, 1200);
+        Reconstruction rec;
+        rec.cameras[1] = K;
+        std::mt19937 rng(13);
+        std::uniform_real_distribution<double> ub(-2.0, 2.0);
+        std::vector<Vec3> pts(N);
+        for (Vec3& p : pts) p = {ub(rng), ub(rng), ub(rng)};
+        std::vector<Vec3> centres = arcCentres(M);
+        for (int i = 0; i < M; i++) {
+            Image im;
+            im.id = (uint32_t)(i + 1);
+            im.camera_id = 1;
+            im.name = "img" + std::to_string(i) + ".jpg";
+            im.pose = lookAt(centres[i], {0, 0, 0});
+            im.registered = true;
+            im.points2D.resize(N);
+            im.point3D_ids.assign(N, kInvalidPoint3D);
+            rec.images[im.id] = im;
+        }
+        auto px = [&](uint32_t img, const Vec3& X) {
+            const Pose& pose = rec.images.at(img).pose;
+            return rec.cameras[1].project(mul(pose.R, X) + pose.t);
+        };
+        for (int j = 0; j < N; j++) {
+            std::vector<TrackElement> track;
+            for (int i = 0; i < M; i++) {
+                rec.images[(uint32_t)(i + 1)].points2D[j] = px((uint32_t)(i + 1), pts[j]);
+                track.push_back({(uint32_t)(i + 1), (uint32_t)j});
+            }
+            rec.addPoint3D(pts[j], track);
+        }
+        // Projections before, so the invariance claim is measured, not assumed.
+        std::vector<Vec2> before;
+        for (const auto& kv : rec.points3D)
+            for (const TrackElement& e : kv.second.track)
+                before.push_back(px(e.image_id, kv.second.xyz));
+
+        MetricRef ref;
+        for (int i = 0; i < M; i++) {
+            ref.centres.push_back(centres[i]);
+            ref.targets.push_back(transformPoint(T, centres[i]));
+            ref.image_ids.push_back((uint32_t)(i + 1));
+        }
+        MetricFit fit = fitMetricGauge(ref, 0.05);
+        check(fit.ok, "T8: ok");
+        applySim3(rec, fit.T);
+        double worst_c = 0;
+        for (int i = 0; i < M; i++) {
+            Vec3 c = cameraCenter(rec.images.at((uint32_t)(i + 1)).pose);
+            worst_c = std::max(worst_c, (c - ref.targets[i]).norm());
+        }
+        check(worst_c <= 1e-9, "T8: every centre lands on its target");
+        size_t k = 0;
+        double worst_px = 0;
+        for (const auto& kv : rec.points3D)
+            for (const TrackElement& e : kv.second.track) {
+                const Vec2 uv = px(e.image_id, kv.second.xyz);
+                worst_px = std::max(worst_px, std::max(std::fabs(uv.x - before[k].x),
+                                                       std::fabs(uv.y - before[k].y)));
+                k++;
+            }
+        check(k == before.size() && k == (size_t)M * N,
+              "T8: the same observations project after the transform");
+        printf("  T8: worst centre %.3e m, worst reprojection %.3e px\n", worst_c, worst_px);
+        // 1e-6 px is what sfm_merge_test asks of the same invariance. The
+        // floor here is ~1e-9 px: a metric frame puts the origin metres away,
+        // and forming s*x_cam cancels two |t|-sized terms.
+        check(worst_px <= 1e-6, "T8: reprojection unchanged");
+    }
+
+    // ---- T9: G4 is wired to the reported rotation uncertainty ------------
+    // One long thin arc at two noise levels. The geometry is identical; only
+    // sigma moves, so a gate that fires on anything else fails this.
+    {
+        Sim3 T;
+        T.scale = 1.7;
+        T.R = rotFromAxisAngle({0.0, 1.0, 0.0}, 0.35);
+        T.t = {5.0, 5.0, 5.0};
+        std::vector<Vec3> thin(60);
+        for (int i = 0; i < 60; i++)
+            thin[i] = {0.5 * i, 0.0009 * i * (i % 2 ? 1 : -1), 0.0007 * ((i / 3) % 5)};
+        std::mt19937 rng(17);
+        auto run = [&](double sigma) {
+            std::normal_distribution<double> nz(0.0, sigma);
+            MetricRef ref = makeRef(thin, T);
+            for (Vec3& p : ref.targets) p = p + Vec3{nz(rng), nz(rng), nz(rng)};
+            return fitMetricGauge(ref, 10.0);
+        };
+        MetricFit loud = run(0.08);
+        MetricFit quiet = run(0.0005);
+        printf("  T9: thin arc rot unc %.3f deg (loud) vs %.4f deg (quiet)\n",
+               loud.rot_unc_deg, quiet.rot_unc_deg);
+        check(!loud.ok && loud.reason == MetricFail::Rotation, "T9: noisy thin arc -> Rotation");
+        check(loud.rot_unc_deg > 5.0, "T9: reported rotation uncertainty above the gate");
+        check(quiet.ok, "T9: the same arc, 100x quieter, passes");
+    }
+
+    // ---- T10: same inputs twice, bit for bit ----------------------------
+    // Two exact 30-camera consensus sets tie under MSAC, so the winner is
+    // whichever the draw reached first; one consensus converges from any seed.
+    {
+        Sim3 A, B;
+        A.scale = 3.3;
+        A.R = rotFromAxisAngle({0.3, 0.3, 0.9}, 2.0);
+        A.t = {-7.0, 1.0, 4.0};
+        B.scale = 1.7;
+        B.R = rotFromAxisAngle({0.9, -0.2, 0.1}, 1.1);
+        B.t = {50.0, -30.0, 12.0};
+        std::vector<Vec3> centres = arcCentres(60);
+        MetricRef ref;
+        ref.centres = centres;
+        for (int i = 0; i < 60; i++)
+            ref.targets.push_back(transformPoint(i < 30 ? A : B, centres[i]));
+        MetricFit a = fitMetricGauge(ref, 0.1);
+        MetricFit b = fitMetricGauge(ref, 0.1);
+        bool same = a.ok == b.ok && a.reason == b.reason && a.T.scale == b.T.scale &&
+                    a.T.t.x == b.T.t.x && a.T.t.y == b.T.t.y && a.T.t.z == b.T.t.z &&
+                    a.inliers == b.inliers && a.inlier_mask == b.inlier_mask &&
+                    a.rms == b.rms && a.scale_unc == b.scale_unc;
+        for (int i = 0; i < 9; i++) same = same && a.T.R[i] == b.T.R[i];
+        printf("  T10: locked onto scale %.4f with %d/%d inliers\n", a.T.scale, a.inliers, a.n);
+        check(same, "T10: two runs agree bit for bit");
+        check(a.inliers == 30, "T10: exactly one of the two consensus sets is found");
+        const bool bimodal = std::fabs(a.T.scale / A.scale - 1.0) < 1e-9 ||
+                             std::fabs(a.T.scale / B.scale - 1.0) < 1e-9;
+        check(bimodal, "T10: the fixture really has two answers to choose between");
+    }
+
+    printf("%s\n", fails ? "FAIL" : "PASS");
+    return fails ? 1 : 0;
+}
+
+int main(int argc, char** argv) { return sfmTestMain(argc, argv, cmdMetricSelftest); }

--- a/src/sfm/tests/sfm_metric_test.cpp
+++ b/src/sfm/tests/sfm_metric_test.cpp
@@ -514,6 +514,219 @@ int cmdMetricSelftest(int, char**) {
         fs::remove_all(dir);
     }
 
+    // ---- T6: the GPS IFD, hand-built, both byte orders ---------------------
+    // IFD0 carries decoy tags 1..6, which are exactly the GPS IFD's own tag
+    // numbers: one switch for both reads latitude out of them.
+    struct Tiff {
+        std::vector<uint8_t> b;
+        bool le;
+        void u8(uint8_t v) { b.push_back(v); }
+        void u16(uint16_t v) {
+            if (le) { u8((uint8_t)v); u8((uint8_t)(v >> 8)); }
+            else { u8((uint8_t)(v >> 8)); u8((uint8_t)v); }
+        }
+        void u32(uint32_t v) {
+            if (le) { u16((uint16_t)v); u16((uint16_t)(v >> 16)); }
+            else { u16((uint16_t)(v >> 16)); u16((uint16_t)v); }
+        }
+        void ent(uint16_t tag, uint16_t type, uint32_t count, uint32_t val) {
+            u16(tag); u16(type); u32(count); u32(val);
+        }
+        // A value of 4 bytes or fewer sits in the entry, left-aligned.
+        void entIn(uint16_t tag, uint16_t type, uint32_t count,
+                   const std::vector<uint8_t>& raw) {
+            u16(tag); u16(type); u32(count);
+            for (int i = 0; i < 4; i++) u8(i < (int)raw.size() ? raw[i] : 0);
+        }
+    };
+    auto build = [](bool le, char latref, char lonref, uint8_t altref, bool with_gps,
+                    uint32_t sec100 = 355, uint32_t lonsec100 = 1786,
+                    bool with_alt = true) {
+        Tiff t;
+        t.le = le;
+        t.u8(le ? 'I' : 'M'); t.u8(le ? 'I' : 'M');
+        t.u16(42);
+        t.u32(8);
+        const uint16_t n0 = with_gps ? 7 : 6;
+        t.u16(n0);
+        for (uint16_t tag = 1; tag <= 6; tag++) t.ent(tag, 3, 1, 0xDEAD);
+        const uint32_t gps = 8 + 2 + (uint32_t)n0 * 12 + 4;
+        if (with_gps) t.ent(0x8825, 4, 1, gps);
+        t.u32(0);
+        if (!with_gps) return t.b;
+        const uint32_t nv = with_alt ? 6 : 5;
+        t.u16((uint16_t)nv);
+        const uint32_t vals = gps + 2 + nv * 12 + 4;
+        t.entIn(1, 2, 2, {(uint8_t)latref, 0});
+        t.ent(2, 5, 3, vals);
+        t.entIn(3, 2, 2, {(uint8_t)lonref, 0});
+        t.ent(4, 5, 3, vals + 24);
+        t.entIn(5, 1, 1, {altref});
+        if (with_alt) t.ent(6, 5, 1, vals + 48);
+        t.u32(0);
+        const uint32_t r[] = {42, 1, 12, 1, sec100, 100,
+                              83, 1, 40, 1, lonsec100, 100,
+                              25366, 100};
+        for (uint32_t v : r) t.u32(v);
+        return t.b;
+    };
+    {
+        const double lat = 42.0 + 12.0 / 60.0 + 3.55 / 3600.0;
+        const double lon = 83.0 + 40.0 / 60.0 + 17.86 / 3600.0;
+        for (bool le : {true, false}) {
+            std::vector<uint8_t> blk = build(le, 'N', 'E', 0, true);
+            ExifData e = parseExifTiff(blk.data(), blk.size());
+            const char* w = le ? "T6 LE" : "T6 BE";
+            check(e.valid && e.has_gps, w);
+            check(std::fabs(e.lat_deg - lat) <= 1e-9, "T6: latitude, both byte orders");
+            check(std::fabs(e.lon_deg - lon) <= 1e-9, "T6: longitude, both byte orders");
+            check(e.has_alt && std::fabs(e.alt_m - 253.66) <= 1e-9, "T6: altitude");
+        }
+        {
+            std::vector<uint8_t> blk = build(true, 'S', 'W', 0, true);
+            ExifData e = parseExifTiff(blk.data(), blk.size());
+            check(std::fabs(e.lat_deg + lat) <= 1e-9, "T6: S is negative");
+            check(std::fabs(e.lon_deg + lon) <= 1e-9, "T6: W is negative");
+        }
+        {   // GPSAltitudeRef 1 means below sea level
+            std::vector<uint8_t> blk = build(true, 'N', 'E', 1, true);
+            ExifData e = parseExifTiff(blk.data(), blk.size());
+            check(std::fabs(e.alt_m + 253.66) <= 1e-9, "T6: altitude ref 1 is below sea level");
+        }
+        {
+            std::vector<uint8_t> blk = build(true, 'N', 'E', 0, false);
+            ExifData e = parseExifTiff(blk.data(), blk.size());
+            check(e.valid && !e.has_gps, "T6: an IFD0 of decoys is not a GPS fix");
+            check(e.lat_deg == 0 && e.lon_deg == 0, "T6: and leaves no position behind");
+        }
+    }
+
+    // ---- T6b: GPS straight off files, through readExif's JPEG walk ---------
+    // Three minimal JPEGs, one with no EXIF at all, so the "no GPS" count is
+    // measured rather than assumed.
+    {
+        namespace fs = std::filesystem;
+        const fs::path dir = fs::temp_directory_path() / "sfm_metric_t6b";
+        fs::remove_all(dir);
+        fs::create_directories(dir / "sub");
+        auto write_jpeg = [&](const fs::path& path, const std::vector<uint8_t>& tiff) {
+            std::vector<uint8_t> j = {0xFF, 0xD8};
+            if (!tiff.empty()) {
+                const uint16_t seg = (uint16_t)(tiff.size() + 8);
+                j.push_back(0xFF);
+                j.push_back(0xE1);
+                j.push_back((uint8_t)(seg >> 8));
+                j.push_back((uint8_t)seg);
+                for (const char* p2 = "Exif"; *p2; p2++) j.push_back((uint8_t)*p2);
+                j.push_back(0);
+                j.push_back(0);
+                j.insert(j.end(), tiff.begin(), tiff.end());
+            }
+            j.push_back(0xFF);
+            j.push_back(0xD9);
+            std::ofstream f(path.string(), std::ios::binary);
+            f.write((const char*)j.data(), (std::streamsize)j.size());
+        };
+        write_jpeg(dir / "a.jpg", build(true, 'N', 'W', 0, true, 355, 1786));
+        write_jpeg(dir / "sub" / "b.jpg", build(true, 'N', 'W', 0, true, 1055, 1786));
+        write_jpeg(dir / "c.jpg", {});
+        write_jpeg(dir / "d.jpg", build(true, 'N', 'W', 0, true, 705, 1786, false));
+        write_jpeg(dir / "e.jpg", build(true, 'N', 'W', 0, true, 355, 1786));
+        Reconstruction rec;
+        const char* names[5] = {"a.jpg", "sub/b.jpg", "c.jpg", "d.jpg", "e.jpg"};
+        for (int i = 0; i < 5; i++) {
+            Image im;
+            im.id = (uint32_t)(i + 1);
+            im.name = names[i];
+            im.registered = i != 4;   // e.jpg has a fix but was never solved
+            im.pose = {mat3Identity(), {(double)-i, 0, 0}};
+            rec.images[im.id] = im;
+        }
+        MetricRef ref;
+        MetricGpsCounts gc = metricRefFromGps(rec, dir.string(), ref);
+        printf("  T6b: gps %d, no-gps %d, no-alt %d\n", gc.matched, gc.no_gps, gc.no_alt);
+        check(gc.matched == 3 && gc.no_gps == 1,
+              "T6b: three fixes, one file without EXIF, one unregistered");
+        check(gc.no_alt == 1, "T6b: the fix with no altitude tag is counted");
+        check(ref.targets.size() == 3 && ref.image_ids.size() == 3,
+              "T6b: the unpositioned and unregistered images are left out");
+        // b.jpg is 7.00 arcseconds of latitude north of a.jpg and nothing
+        // else. 215.99 m by the meridional radius; a sphere of radius a gives
+        // 216.43, so 0.05 m of tolerance is what refuses a flat-earth ENU.
+        const Vec3 d = ref.targets[1] - ref.targets[0];
+        printf("  T6b: b - a = (%.4f, %.4f, %.4f) m\n", d.x, d.y, d.z);
+        check(std::fabs(d.y - 215.99) < 0.05 && std::fabs(d.x) < 0.01,
+              "T6b: 216 m due north, by the meridional radius not by a");
+        fs::remove_all(dir);
+    }
+
+    // ---- T7: WGS-84, against vectors computed outside this program ---------
+    // (0,0,0) and (90,0,0) are the semi-axes and exact by inspection; float
+    // ECEF cannot reach 1e-6 m on any of the four.
+    {
+        struct Case { double lat, lon, h, X, Y, Z; };
+        const Case cs[4] = {
+            {0, 0, 0, 6378137.000000, 0.0, 0.0},
+            {90, 0, 0, 0.0, 0.0, 6356752.314245},
+            {45, 0, 0, 4517590.878849, 0.0, 4487348.408866},
+            {42.216, -83.664, 253.66, 522118.504341, -4702200.844425, 4263573.714297},
+        };
+        double worst = 0;
+        for (const Case& c : cs) {
+            const Vec3 p = ecefFromGeodetic(c.lat, c.lon, c.h);
+            worst = std::max(worst, std::max(std::fabs(p.x - c.X),
+                                             std::max(std::fabs(p.y - c.Y),
+                                                      std::fabs(p.z - c.Z))));
+        }
+        printf("  T7: worst ECEF error %.3e m\n", worst);
+        check(worst <= 1e-6, "T7: the four pinned ECEF vectors");
+
+        const double lat0 = 42.216, lon0 = -83.664, h0 = 253.66;
+        std::vector<Geodetic> g = {{lat0, lon0, h0},
+                                   {lat0 + 0.001, lon0, h0},
+                                   {lat0, lon0 + 0.001, h0},
+                                   {lat0, lon0, h0 + 10.0}};
+        std::vector<Vec3> enu = enuFromGeodetic(g, Geodetic{lat0, lon0, h0});
+        const Vec3 o = enu[0];
+        const double want[3][3] = {{-0.000000, 111.081917, -0.000969},
+                                   {82.573260, 0.000484, -0.000534},
+                                   {0.0, 0.0, 10.000000}};
+        double we = 0;
+        for (int i = 0; i < 3; i++) {
+            const Vec3 d = enu[i + 1] - o;
+            we = std::max(we, std::max(std::fabs(d.x - want[i][0]),
+                                       std::max(std::fabs(d.y - want[i][1]),
+                                                std::fabs(d.z - want[i][2]))));
+        }
+        printf("  T7: worst ENU displacement error %.3e m\n", we);
+        check(we <= 1e-6, "T7: the three pinned ENU displacements");
+        // A permuted or mirrored axis set leaves every fit RMS unchanged --
+        // the Sim3 absorbs it -- so only the named axes can catch one.
+        const Vec3 north = enu[1] - o, east = enu[2] - o, up = enu[3] - o;
+        check(north.y > 100.0 && std::fabs(north.x) < 1.0, "T7: +latitude is +N");
+        check(east.x > 80.0 && std::fabs(east.y) < 1.0, "T7: +longitude is +E");
+        check(up.z > 9.9, "T7: +height is +U");
+        check(east.normalized().cross(north.normalized()).dot(up.normalized()) > 0.999,
+              "T7: E x N = U, from the fitted axes");
+        // The origin --metric-gps uses is the arithmetic mean of the fixes.
+        // It is not the ECEF centroid -- that leaves 3e-4 m of offset here,
+        // which the Sim3's translation absorbs.
+        Geodetic mo;
+        for (const Geodetic& q : g) {
+            mo.lat_deg += q.lat_deg / g.size();
+            mo.lon_deg += q.lon_deg / g.size();
+            mo.alt_m += q.alt_m / g.size();
+        }
+        std::vector<Vec3> by_mean = enuFromGeodetic(g);
+        std::vector<Vec3> by_hand = enuFromGeodetic(g, mo);
+        double dm = 0;
+        for (size_t i = 0; i < g.size(); i++) dm = std::max(dm, (by_mean[i] - by_hand[i]).norm());
+        check(dm == 0.0, "T7: the default origin is the mean of the fixes");
+        check((by_mean[0] - by_hand[0]).norm() == 0.0 &&
+                  (by_mean[0] - enuFromGeodetic(g, g[0])[0]).norm() > 1e-3,
+              "T7: and not the first fix");
+    }
+
     printf("%s\n", fails ? "FAIL" : "PASS");
     return fails ? 1 : 0;
 }

--- a/src/sfm/tests/sfm_metric_test.cpp
+++ b/src/sfm/tests/sfm_metric_test.cpp
@@ -742,6 +742,36 @@ int cmdMetricSelftest(int, char**) {
               "T7: and not the first fix");
     }
 
+    // ---- T11: the conditioning floor is pinned from both sides -------------
+    // A line with a chosen transverse spread. 0.045 and 0.055 straddle the
+    // constant, so moving it outside +/-10 % turns one of these red.
+    {
+        Sim3 T;
+        T.scale = 2.5;
+        T.R = rotFromAxisAngle({0.2, 0.5, 0.84}, 0.7);
+        T.t = {3.0, -1.0, 8.0};
+        // lambda1 = (n^2-1)/12 along x, lambda2 = a^2, so perp_frac is
+        // sqrt(a^2/(lambda1+a^2)); the + - - + sign pattern makes the cross
+        // covariance with x exactly zero, so those are the true eigenvalues.
+        auto line = [](double a) {
+            std::vector<Vec3> c(60);
+            for (int i = 0; i < 60; i++) {
+                const int j = i % 4;
+                c[i] = {(double)i, (j == 0 || j == 3) ? a : -a, 0.0};
+            }
+            return c;
+        };
+        MetricFit below = fitMetricGauge(makeRef(line(0.780105), T), 0.5);
+        MetricFit above = fitMetricGauge(makeRef(line(0.953940), T), 0.5);
+        printf("  T11: perp frac %.6f (below the floor) / %.6f (above)\n",
+               below.perp_frac, above.perp_frac);
+        check(std::fabs(below.perp_frac - 0.045) < 1e-6, "T11: the low fixture really is 0.045");
+        check(std::fabs(above.perp_frac - 0.055) < 1e-6, "T11: the high fixture really is 0.055");
+        check(!below.ok && below.reason == MetricFail::Collinear,
+              "T11: 0.045 is refused, so the floor is not below it");
+        check(above.ok, "T11: 0.055 is accepted, so the floor is not above it");
+    }
+
     printf("%s\n", fails ? "FAIL" : "PASS");
     return fails ? 1 : 0;
 }

--- a/src/sfm/tests/sfm_metric_test.cpp
+++ b/src/sfm/tests/sfm_metric_test.cpp
@@ -258,7 +258,7 @@ int cmdMetricSelftest(int, char**) {
                 ref.targets.push_back({1.6 * i, 0, 0});
             }
             MetricFit fit = fitMetricGauge(ref, 0.5);
-            check(!fit.ok && fit.reason == MetricFail::Rotation, "T4: collinear -> Rotation");
+            check(!fit.ok && fit.reason == MetricFail::Collinear, "T4: collinear -> Collinear");
         }
         {   // every reference position wrong by far more than max_error
             MetricRef ref = makeRef(arcCentres(20), T);
@@ -368,9 +368,9 @@ int cmdMetricSelftest(int, char**) {
         check(worst_px <= 1e-6, "T8: reprojection unchanged");
     }
 
-    // ---- T9: G4 is wired to the reported rotation uncertainty ------------
-    // One long thin arc at two noise levels. The geometry is identical; only
-    // sigma moves, so a gate that fires on anything else fails this.
+    // ---- T9: the collinearity gate does not read the noise ----------------
+    // Same thin arc at two noise levels 160x apart. A gate on the reported
+    // orientation uncertainty passes the quiet one; this one refuses both.
     {
         Sim3 T;
         T.scale = 1.7;
@@ -380,19 +380,29 @@ int cmdMetricSelftest(int, char**) {
         for (int i = 0; i < 60; i++)
             thin[i] = {0.5 * i, 0.0009 * i * (i % 2 ? 1 : -1), 0.0007 * ((i / 3) % 5)};
         std::mt19937 rng(17);
-        auto run = [&](double sigma) {
+        auto run = [&](const std::vector<Vec3>& c, double sigma) {
             std::normal_distribution<double> nz(0.0, sigma);
-            MetricRef ref = makeRef(thin, T);
+            MetricRef ref = makeRef(c, T);
             for (Vec3& p : ref.targets) p = p + Vec3{nz(rng), nz(rng), nz(rng)};
             return fitMetricGauge(ref, 10.0);
         };
-        MetricFit loud = run(0.08);
-        MetricFit quiet = run(0.0005);
-        printf("  T9: thin arc rot unc %.3f deg (loud) vs %.4f deg (quiet)\n",
-               loud.rot_unc_deg, quiet.rot_unc_deg);
-        check(!loud.ok && loud.reason == MetricFail::Rotation, "T9: noisy thin arc -> Rotation");
-        check(loud.rot_unc_deg > 5.0, "T9: reported rotation uncertainty above the gate");
-        check(quiet.ok, "T9: the same arc, 100x quieter, passes");
+        MetricFit loud = run(thin, 0.08);
+        MetricFit quiet = run(thin, 0.0005);
+        printf("  T9: thin arc perp frac %.5f (loud) / %.5f (quiet); rot unc %.3f / %.4f deg\n",
+               loud.perp_frac, quiet.perp_frac, loud.rot_unc_deg, quiet.rot_unc_deg);
+        check(!loud.ok && loud.reason == MetricFail::Collinear, "T9: thin arc -> Collinear");
+        check(!quiet.ok && quiet.reason == MetricFail::Collinear,
+              "T9: and 160x quieter is still Collinear -- geometry, not noise");
+        check(quiet.rot_unc_deg < 5.0 && loud.rot_unc_deg > 5.0,
+              "T9: the reported uncertainty WOULD have split them, which is why it cannot gate");
+        check(loud.perp_frac < 0.05 && quiet.perp_frac < 0.05, "T9: both below the floor");
+        // The same 60 cameras spread across the long axis instead: passes.
+        std::vector<Vec3> fat(60);
+        for (int i = 0; i < 60; i++)
+            fat[i] = {0.5 * i, 4.0 * std::sin(0.3 * i), 3.0 * std::cos(0.21 * i)};
+        MetricFit ok = run(fat, 0.08);
+        printf("  T9: spread arc perp frac %.4f\n", ok.perp_frac);
+        check(ok.ok, "T9: the same cameras spread off the axis pass");
     }
 
     // ---- T10: same inputs twice, bit for bit ----------------------------
@@ -411,15 +421,20 @@ int cmdMetricSelftest(int, char**) {
         ref.centres = centres;
         for (int i = 0; i < 60; i++)
             ref.targets.push_back(transformPoint(i < 30 ? A : B, centres[i]));
+        // Eight fits, not two: which set wins is a coin flip per seed, so a pair
+        // that happens to agree proves nothing about a varying one.
         MetricFit a = fitMetricGauge(ref, 0.1);
-        MetricFit b = fitMetricGauge(ref, 0.1);
-        bool same = a.ok == b.ok && a.reason == b.reason && a.T.scale == b.T.scale &&
-                    a.T.t.x == b.T.t.x && a.T.t.y == b.T.t.y && a.T.t.z == b.T.t.z &&
-                    a.inliers == b.inliers && a.inlier_mask == b.inlier_mask &&
-                    a.rms == b.rms && a.scale_unc == b.scale_unc;
-        for (int i = 0; i < 9; i++) same = same && a.T.R[i] == b.T.R[i];
+        bool same = true;
+        for (int rep = 0; rep < 7; rep++) {
+            MetricFit b = fitMetricGauge(ref, 0.1);
+            same = same && a.ok == b.ok && a.reason == b.reason && a.T.scale == b.T.scale &&
+                   a.T.t.x == b.T.t.x && a.T.t.y == b.T.t.y && a.T.t.z == b.T.t.z &&
+                   a.inliers == b.inliers && a.inlier_mask == b.inlier_mask &&
+                   a.rms == b.rms && a.scale_unc == b.scale_unc && a.perp_frac == b.perp_frac;
+            for (int i = 0; i < 9; i++) same = same && a.T.R[i] == b.T.R[i];
+        }
         printf("  T10: locked onto scale %.4f with %d/%d inliers\n", a.T.scale, a.inliers, a.n);
-        check(same, "T10: two runs agree bit for bit");
+        check(same, "T10: eight runs agree bit for bit");
         check(a.inliers == 30, "T10: exactly one of the two consensus sets is found");
         const bool bimodal = std::fabs(a.T.scale / A.scale - 1.0) < 1e-9 ||
                              std::fabs(a.T.scale / B.scale - 1.0) < 1e-9;

--- a/src/sfm/tests/sfm_metric_test.cpp
+++ b/src/sfm/tests/sfm_metric_test.cpp
@@ -4,7 +4,10 @@
 // Prints PASS/FAIL and returns 0/1. See docs/testing.md.
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <random>
+#include <string>
 #include <vector>
 
 #include "sfm/core/Camera.h"
@@ -421,6 +424,94 @@ int cmdMetricSelftest(int, char**) {
         const bool bimodal = std::fabs(a.T.scale / A.scale - 1.0) < 1e-9 ||
                              std::fabs(a.T.scale / B.scale - 1.0) < 1e-9;
         check(bimodal, "T10: the fixture really has two answers to choose between");
+    }
+
+    // ---- T5: pairing a positions file to image names ----------------------
+    // Two files share a basename in different folders, one entry has no
+    // extension, one names an image the model does not have.
+    {
+        namespace fs = std::filesystem;
+        const fs::path dir = fs::temp_directory_path() / "sfm_metric_t5";
+        fs::remove_all(dir);
+        fs::create_directories(dir);
+        const fs::path pf = dir / "positions.txt";
+        {
+            std::ofstream f(pf.string());
+            f << "# a comment, and the blank line below\n\n";
+            f << "cam1/a.jpg 1 2 3\n";
+            f << "cam2/a.jpg 4 5 6\n";
+            f << "b 7 8 9\n";              // stem match against b.png
+            f << "zzz.jpg 10 11 12\n";     // not in the model
+            f << "e.jpg 20 21 22\n";       // in the model, but unregistered
+            f << "v1 99 99 99\n";          // a dot in a FOLDER is not an extension
+        }
+        std::map<std::string, Vec3> pos;
+        std::string err;
+        check(readMetricPositions(pf.string(), pos, err), "T5: the file parses");
+        check(pos.size() == 6, "T5: six entries read");
+
+        Reconstruction rec;
+        const char* names[6] = {"cam1/a.jpg", "cam2/a.jpg", "b.png", "d.jpg", "e.jpg",
+                                "v1.0/frame"};
+        for (int i = 0; i < 6; i++) {
+            Image im;
+            im.id = (uint32_t)(i + 1);
+            im.name = names[i];
+            im.registered = i != 4;  // e.jpg is in the model but not solved
+            im.pose = {mat3Identity(), {(double)-i, 0, 0}};
+            rec.images[im.id] = im;
+        }
+        MetricRef ref;
+        MetricPairCounts pc = pairMetricRef(rec, pos, ref);
+        printf("  T5: matched %d, file-only %d, model-only %d\n",
+               pc.matched, pc.unmatched_file, pc.unmatched_model);
+        check(pc.matched == 3 && (int)ref.targets.size() == 3, "T5: three matched");
+        check(pc.unmatched_file == 3, "T5: an unregistered image leaves its entry unused");
+        check(pc.unmatched_model == 2, "T5: a dotted folder is not an extension");
+        std::map<uint32_t, Vec3> got;
+        for (size_t i = 0; i < ref.image_ids.size(); i++) got[ref.image_ids[i]] = ref.targets[i];
+        check(got.count(1) && got.count(2) && got.count(3), "T5: the expected three images");
+        check(got.count(1) && got[1].x == 1 && got[1].y == 2 && got[1].z == 3 &&
+              got.count(2) && got[2].x == 4 && got[2].y == 5 && got[2].z == 6,
+              "T5: same basename in two folders stays two cameras");
+        check(got.count(3) && got[3].x == 7, "T5: an extensionless entry matches by stem");
+
+        {   // a malformed line is refused, and the message names its number
+            const fs::path bad = dir / "bad.txt";
+            std::ofstream f(bad.string());
+            f << "ok.jpg 1 2 3\n\nbroken.jpg 1 2\n";
+            f.close();
+            std::map<std::string, Vec3> p2;
+            std::string e2;
+            check(!readMetricPositions(bad.string(), p2, e2), "T5: a short line is refused");
+            check(e2.find("3") != std::string::npos, "T5: the error names line 3");
+        }
+        {   // a fourth number is not a comment: refuse rather than ignore it
+            const fs::path junk = dir / "junk.txt";
+            std::ofstream f(junk.string());
+            f << "ok.jpg 1 2 3 4\n";
+            f.close();
+            std::map<std::string, Vec3> pj;
+            std::string ej;
+            check(!readMetricPositions(junk.string(), pj, ej),
+                  "T5: a trailing field is refused");
+        }
+        {   // the same image twice is a mistake, not a last-one-wins
+            const fs::path dup = dir / "dup.txt";
+            std::ofstream f(dup.string());
+            f << "a.jpg 1 2 3\na.jpg 4 5 6\n";
+            f.close();
+            std::map<std::string, Vec3> p3;
+            std::string e3;
+            check(!readMetricPositions(dup.string(), p3, e3), "T5: a repeated name is refused");
+        }
+        {   // a path that is not there reports so rather than reading nothing
+            std::map<std::string, Vec3> p4;
+            std::string e4;
+            check(!readMetricPositions((dir / "nope.txt").string(), p4, e4),
+                  "T5: a missing file is refused");
+        }
+        fs::remove_all(dir);
     }
 
     printf("%s\n", fails ? "FAIL" : "PASS");


### PR DESCRIPTION
Following #56, where you said you could work on metric scale from IMU, LiDAR or GPS if it were a
popular request, and we offered to write it. This is that, for two of the three sources.

`spirula sfm` learns an optional metric gauge from paired camera positions — a COLMAP-format
positions file, or GPS read from image EXIF — and applies it at model-write time via the existing
`Orient.h` path, so the trainer, viewer, mesh and export need no changes. Three additive flags,
one new exit status. Default behaviour is byte-identical when no metric source is given.

It reuses `estimateSim3`, `jacobiEigenSymmetric`, the RANSAC helpers and `uprightTransform`
unchanged — no second implementation of anything, no new dependency.

## Three things worth leading with

**1. The fit agrees with an independent implementation to one ulp.** We already had this maths in
Python; the C++ and the Python, given identical inputs, agree on scale to **4.441e-16** relative
across four fixtures, with rotation exactly `0.000e+00` deg. The pre-registered bar was 1e-9.
Rounding the same inputs to float32 moves the fit by **2.706e-09**, so the agreement is roughly
six orders tighter than the arithmetic's own sensitivity to its inputs — it is not a coincidence
of one fixture.

**2. The design is shaped by one of our own gates failing, and that is not a footnote.** We first
derived scale and orientation uncertainties in closed form from inlier residuals and gated on
them at 2 % and 5 deg. On real flight data those gates **under-state real error by 3.9–4.5x**,
because GPS error is correlated rather than white: over a short window it is nearly a constant
offset the Sim3's translation absorbs. Measured on sub-windows of a track whose true scale is
known, **the 2 % scale gate passed a 3.6 % scale error.**

So the statistical gates are now advisory — still computed, still printed, explicitly labelled as
assuming uncorrelated error and being a lower bound — and the hard gates are the ones that do not
depend on a noise model: minimum spread, inlier count, and a conditioning test on the reference
geometry. That change made the feature strictly better on the same data: it now refuses a window
carrying 0.277 % of real scale error that the statistical gate waved through.

**3. One thing is deliberately not in this diff, because it is your call.** `merge` refuses a
single model, so a user with a finished model and a GPS track cannot currently reach this. The
change is about six lines — relax `models.size() < 2` when a metric source is given, and skip
`mergeModels` for that case — but repurposing a subcommand's semantics is an interface decision
that should be yours, not ours. Every measurement below that used `merge` did so through a
two-copy `--no-ba` harness, which is a test route rather than a user path. Happy to send it as a
follow-up if you want it, in whatever shape you prefer.

## What it does

```
spirula sfm auto <images> -o <ws> --metric-gps [--metric-max-error 3]
spirula sfm auto <images> -o <ws> --metric-positions positions.txt
```

`positions.txt` is COLMAP `model_aligner` format — `image_name X Y Z`, any right-handed metric
frame. GPS is read from `GPSLatitude` / `GPSLongitude` / `GPSAltitude` and converted through
WGS-84 ECEF to a local ENU frame about the first fix.

On success the model is written in the metric gauge and the log reports the fitted scale, the
inlier RMS, the inlier count, and the two advisory uncertainties. On failure it reports which gate
fired and why, and **exits 4 with the model still written in its previous gauge** — a wrong scale
is harder to notice than no scale, so failing loudly was a design requirement from the start.

## Verification

Two real drone flights, 161 frames each at two sites, registered 161/161 from scratch, all frames
carrying a GPS fix:

| | scale | inlier RMS | scale unc | orient unc |
|---|---|---|---|---|
| site A | 9.699277 | 0.4247 m | 0.038 % | 0.056 deg |
| site B | 31.574814 | 0.5516 m | 0.029 % | 0.028 deg |

Median inter-camera distance error against the reference track: **0.5761 %**. EXIF and a positions
file built from the same telemetry agree on scale to **2.09e-4** and **3.20e-5**.

An indoor 196-frame ARKit sequence fits at RMS 0.0300 m with a median inter-camera error of
0.9738 %. Read that as floor-limited rather than as a clean margin: 3 cm of ARKit drift over
1.33 m median baselines supports about 2 % per pair on its own.

**Negative fixtures fire where predicted**, against values computed from telemetry before any of
this C++ existed: a hover segment trips the spread gate; a straight leg and a near-straight leg
both trip the conditioning gate; a 16-image set where every frame carries an identical GPS fix
trips spread at radius 0.000 m. In that last case `cmdAuto` returns **3**, not 4 — the
reconstruction's own PARTIAL verdict is reported first, which we think is the right ordering, but
a script gating on `rc == 4` alone would miss it, so it is worth knowing.

**A metric model trains the same as a unit one.** Two datasets differing by exactly one similarity
(12.4x, rotation off identity 9.0e-16), three training repeats each: PSNR differs by 0.079 dB,
splat counts identical in all six arms. The caveat matters more than the pass — with a hard-coded
seed and identical splat counts, this trainer's own repeat SD is **0.401 dB**, so no A/B here can
claim anything under about 0.8 dB.

## Honest limits

**The conditioning threshold is a starting heuristic, not a derived bound.** It requires the
reference positions to have at least 5 % of their spread transverse to the dominant direction,
from an argument that orientation error is amplified against scale error by the inverse of that
fraction. The argument gives the shape and an order of magnitude; it does not give 20x rather than
10x or 30x. It was checked against four sub-windows of one flight, chosen to test predicted
verdicts rather than to sample the amplification distribution — and **nothing has been measured
between 2x and 20x**, the region bordering the cutoff. The missing experiment is a fifth window
picked for amplification density in that band; a well-behaved 10x window supports the threshold, a
10x window carrying percent-level error refutes it. The constant is pinned by a test so it cannot
drift silently.

**The advisory uncertainties assume uncorrelated reference error and are a lower bound**, as above.
They are labelled as such in the output.

**This is 1706 insertions, which is nearly double what we set out to write, and worth saying rather
than leaving to be found.** The breakdown: `sfm_metric_test.cpp` **779** (your own `sfm_*_test.cpp`
run 183–988), translations **353** (18 messages x 13 languages, mechanical, no new font
codepoints), implementation and CLI **547**, docs **27**. What reads for correctness is the 547.
If you would rather it were smaller, the EXIF/GPS source is the last commit by design and lifts
out cleanly — `Exif.h`, the geodetic blocks, three tests and one CLI branch, about 440 lines —
leaving the positions-file path alone. Nothing else separates: the fit, the gates, the pairing and
the wiring are one unit. We kept GPS in because a positions file is a hook that mostly serves us,
while GPS is the source your drone users already have.

## Build and test posture

`build_develop.bash -DSS_BUILD_CLI=ON -DSS_BACKEND=vulkan -DSS_BUILD_SFM=ON` clean, including all
six lints (`check_i18n` 2187/2187 across 13 languages, `check_font_coverage`, `check_comments`,
`check_ss_prefix`, `check_file_macro`, `check_private_paths`).

9 of 10 `sfm_*_test` pass. `sfm_equirect_seam_test` returns 2 **on the untouched upstream tip on
this machine as well** — its F64 arms cannot run because MoltenVK has no fp64. That file is not
touched by this diff.

CUDA is not built here (no CUDA machine); the change is confined to `src/sfm/` and
`src/app/cli/`, which a CUDA build excludes by default.

Happy to adjust any of this — shape, flag names, where it lives, whether GPS belongs in the same
PR. And glad to test whatever you would like on real paired camera and LiDAR captures.
