### PR TITLE
video: probe metadata without a decode session

### DIFF
--- a/src/app/gui/DatasetPrep.cpp
+++ b/src/app/gui/DatasetPrep.cpp
@@ -932,12 +932,11 @@ int64_t DatasetPrep::estimate_frames(const PrepJob& job, const PrepInput& in,
 #ifdef SS_HAVE_VIDEO
     if (!job.force_external_decode && backends().builtin_video) {
         std::string err;
-        const int tracks = app::video_track_count(in.path, err);
-        video::VideoReader r;
-        if (tracks > 0 && r.open(in.path))
-            return expected_frames(job, r.info().fps > 1.0 ? r.info().fps : 30.0,
-                                   r.info().frame_count,
-                                   per_frame > 0 ? per_frame : tracks);
+        video::VideoProbe probe;
+        if (video::probe_video(in.path, probe, err) && probe.tracks > 0)
+            return expected_frames(job, probe.fps > 1.0 ? probe.fps : 30.0,
+                                   probe.frame_count,
+                                   per_frame > 0 ? per_frame : probe.tracks);
     }
 #endif
     VideoFacts facts;
@@ -1244,11 +1243,9 @@ bool DatasetPrep::extract_video(const PrepJob& job, const PrepInput& in,
     return ok;
 }
 
-// Extraction writes frames and nothing else. Masking used to ride along on the
-// decode, which was cheaper by one JPEG decode per frame and cost the user the
-// ability to see the frames before deciding what to mask, to re-mask without
-// re-extracting, and to have photos and video take the same path. The decode it
-// saved is hidden behind the model anyway (generate_masks_builtin reads ahead).
+// Extraction writes frames and nothing else: masking is a separate pass
+// (generate_masks_builtin), so frames are visible before the user chooses
+// masks and re-masking costs no re-extraction.
 bool DatasetPrep::extract_video_builtin(const PrepJob& job, const PrepInput& in,
                                         const std::string& images,
                                         PrepResult& out, std::string& error) {
@@ -1263,8 +1260,8 @@ bool DatasetPrep::extract_video_builtin(const PrepJob& job, const PrepInput& in,
     // fps -> "one frame every N source frames". The source rate is what the
     // container states; a variable-rate file is close enough for this.
     std::string probe_err;
-    const int tracks = app::video_track_count(in.path, probe_err);
-    if (tracks <= 0) {
+    video::VideoProbe probe;
+    if (!video::probe_video(in.path, probe, probe_err) || probe.tracks <= 0) {
         error = probe_err.empty() ? "no video track" : probe_err;
         return false;
     }
@@ -1272,13 +1269,9 @@ bool DatasetPrep::extract_video_builtin(const PrepJob& job, const PrepInput& in,
         in.eac360.valid() ? app::pano360_views(in.eac360, job.pano)
                           : std::vector<app::Pano360View>();
     if (!views.empty()) out.per_folder_cameras = views.size() > 1;
-    else if (tracks > 1) out.per_folder_cameras = true;
+    else if (probe.tracks > 1) out.per_folder_cameras = true;
 
-    double src_fps = 30.0;
-    {
-        video::VideoReader r;
-        if (r.open(in.path) && r.info().fps > 1.0) src_fps = r.info().fps;
-    }
+    const double src_fps = probe.fps > 1.0 ? probe.fps : 30.0;
     const int window = std::max(job.sharp_window, 1);
     const int skip = frame_skip(job, src_fps);
 

--- a/src/video/Video.h
+++ b/src/video/Video.h
@@ -13,6 +13,7 @@
 
 #include "nn/io/Image.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -25,6 +26,22 @@ struct VideoInfo {
     double fps = 0.0;
     std::string codec;        // "h264" | "h265" | "av1"
 };
+
+// Container metadata without a decode session: the header tables the
+// demuxer reads, nothing on the GPU. `tracks` counts the file's video
+// tracks; width/height/fps/frame_count/codec are the first track's.
+struct VideoProbe {
+    int         tracks = 0;
+    int         width = 0;
+    int         height = 0;
+    int64_t     frame_count = 0;   // 0 when the container does not state it
+    double      fps = 0.0;
+    std::string codec;             // "h264" | "h265" | "av1"
+};
+
+// What a file contains, without the decode session open() builds. False
+// with `error` set when the file has no readable video track.
+bool probe_video(const std::string& path, VideoProbe& out, std::string& error);
 
 class VideoReader {
 public:

--- a/src/video/VideoDecoder.cpp
+++ b/src/video/VideoDecoder.cpp
@@ -8,10 +8,27 @@
 
 #include "nn/core/Log.h"
 #include "video/Common.h"
+#include "video/Demuxer.h"
 #include "video/Video.h"
 #include "video/VideoPipeline.h"
 
 namespace video {
+
+bool probe_video(const std::string& path, VideoProbe& out, std::string& error) {
+    // Both demuxers refuse a file with no supported video track, so a
+    // successful open always names at least one track.
+    std::unique_ptr<Demuxer> demux = open_demuxer(path, error);
+    if (!demux) return false;
+    const std::vector<TrackInfo>& tracks = demux->tracks();
+    const TrackInfo& t = tracks[0];
+    out.tracks = (int)tracks.size();
+    out.width = t.width;
+    out.height = t.height;
+    out.frame_count = t.frame_count;
+    out.fps = t.fps;
+    out.codec = codec_name(t.codec);
+    return true;
+}
 
 struct VideoReader::Impl {
     video::VideoPipeline pipe;


### PR DESCRIPTION
Fixes #64.

## What changed

`DatasetPrep` asked the container for fps and frame count by opening the
video, which builds a full `VkVideoSession`, DPB array image and
output-picture pool on the GPU. For a 3840×3840 10-bit stream that is
~500 MB of allocation and teardown, and the GUI did it **twice per file**
before a single frame was decoded:

- `estimate_frames()` — progress-bar total
- `extract_video_builtin()` — frame-skip interval

Neither answer needs the decoder. The demuxer's track table already
carries fps, frame count, size and codec — `video_track_count` already
proved the demuxer-only path. This adds `video::probe_video(path, out,
error)`, which opens the demuxer and reads `tracks[0]`, and points both
call sites at it.

`VideoReader` keeps its signature and still builds the session — the
frame-iteration callers (`PreviewFrames`, `SegmentPanel`, `sam extract`)
are unchanged.

Effect: the pre-extraction phase opens one decode session per track
instead of one extra per track, and the expected-frames probe no longer
touches the GPU at all.

Also condenses the 5-line block above `extract_video_builtin` to the
3-line budget (it was narration of a previous design; the rule requires
fixing over-budget comments in a touched function, in the same diff).

## Verification

- `g++ -fsyntax-only` on the real `VideoDecoder.cpp` (with system Vulkan
  headers) — clean.
- Standalone functional test: the real `Mp4Demuxer.cpp` + `MkvDemuxer.cpp`
  + `probe_video` compiled and run against four synthetic files:

  | file | result |
  |---|---|
  | dual-track h265 3840×3840, 50 fps, 1122 frames | PASS — tracks=2, fps=50, frames=1122, codec=h265 |
  | single-track h264 1920×1080, 30 fps, 90 frames | PASS — tracks=1, fps=30, frames=90, codec=h264 |
  | audio-only MP4 | PASS — rejected with "no supported video track" |
  | non-container binary | PASS — rejected with "not a recognized container" |

- All `build_develop.bash` guards pass: `check_comment_length`,
  `check_ss_prefix`, `check_file_macro`, `check_comments`, `check_i18n`,
  `check_font_coverage`.

A full `cmake` build was not possible in the review environment (no
Vulkan toolkit installed); the two changed call sites are a drop-in
replacement inside the existing `#ifdef SS_HAVE_VIDEO` blocks.

## Note

`PreviewFrames::collect_preview_frames` has the same metadata-only open
pattern (frame_count + fps for the slider, then the reader is destroyed).
Left out of this diff to keep it scoped to #64; can follow up.