### PR TITLE
Fix GUI link with SS_BUILD_SFM=OFF

### DIFF
--- a/src/app/gui/SfmInProcess.cpp
+++ b/src/app/gui/SfmInProcess.cpp
@@ -2,6 +2,7 @@
 
 #include "app/gui/SfmInProcess.h"
 
+#ifdef SS_TOOL_SFM
 #include "sfm/Pipeline.h"
 #include "sfm/core/Cancel.h"
 #include "sfm/core/Events.h"
@@ -128,3 +129,23 @@ InProcessResult run_sfm_in_process(
 }
 
 }  // namespace gui
+
+#else  // no SfM module: SfmRunner::availability() refuses the run before this
+
+#include "i18n/catalog/Log.h"
+
+namespace gui {
+
+InProcessResult run_sfm_in_process(const std::vector<std::string>&,
+                                   const std::function<void(const std::string&)>&,
+                                   const std::function<void(const RunStatus&)>&,
+                                   const std::atomic<bool>&) {
+    InProcessResult out;
+    out.exit_code = 1;
+    out.error = spirula::i18n::msg::log::err_no_sfm_module.get();
+    return out;
+}
+
+}  // namespace gui
+
+#endif

--- a/src/app/gui/SfmRunner.cpp
+++ b/src/app/gui/SfmRunner.cpp
@@ -502,11 +502,13 @@ std::vector<std::string> SfmRunner::recon_args(const SfmJob& job,
     // Not flags any more: the groups go in the manifest. Its text joins the
     // stamp so that changing a lens still counts as a different model
     // (recon_stamp_change), which is the whole point of this list.
+#ifdef SS_TOOL_SFM
     const std::string manifest = sfm::manifest_write(build_manifest(job, prep));
     if (!manifest.empty()) {
         argv.push_back("--manifest");
         argv.push_back(manifest);
     }
+#endif
     if (job.max_features > 0) {
         // Each frontend has its own count flag: the budgets are not comparable,
         // a learned detector emitting a few thousand better-localized points


### PR DESCRIPTION
The GUI does not link when the SfM module is off. SfmInProcess.cpp is globbed into the GUI and calls into ss_sfm unconditionally, and SfmRunner::recon_args calls sfm::manifest_write outside its SS_TOOL_SFM guards. ss_sfm is only linked when SS_BUILD_SFM is on, so a build with it off fails with unresolved sfm:: symbols.

SS_BUILD_SFM defaults to off for CUDA builds, so a CUDA build with the GUI and default options hits this. CI builds Vulkan, where it defaults to on, which is why it did not show up there.

This puts the body of SfmInProcess.cpp and the manifest_write call behind SS_TOOL_SFM, the same way SfmRunner.cpp already guards the rest. Without the module the stub returns err_no_sfm_module, which is what SfmRunner::availability() already reports, so the GUI refuses the run before it gets that far.